### PR TITLE
Define BOOTIF in extrabootoptions

### DIFF
--- a/templates/releng/archlinux.ipxe
+++ b/templates/releng/archlinux.ipxe
@@ -9,7 +9,7 @@ imgtrust
 
 # initial options
 set release {{ releases.0 }}
-set extrabootoptions ip=dhcp net.ifnames=0
+set extrabootoptions ip=dhcp net.ifnames=0 BOOTIF=01-${netX/mac}
 set countrycode
 
 :main


### PR DESCRIPTION
Since this script sets 'ip=dhcp' by default, archiso_pxe_common will fail if more than one network interface exists, and at least one interface cannot be configured by dhcp. Setting BOOTIF will define which interface that archiso_pxe_common should configure, and will cause it to ignore the rest.

Fixes https://bugs.archlinux.org/task/50448