### PR TITLE
Remove invalid filter call from mirrors/status_table.html

### DIFF
--- a/templates/mirrors/status_table.html
+++ b/templates/mirrors/status_table.html
@@ -14,12 +14,12 @@
         </tr>
     </thead>
     <tbody>
-        {% for m_url in urls %}<tr class="{% cycle 'odd' 'even' }}">
+        {% for m_url in urls %}<tr class="{% cycle 'odd' 'even' %}">
             <td>{{ m_url.url }}</td>
             <td>{{ m_url.protocol }}</td>
             <td class="country">{% country_flag m_url.country %}{{ m_url.country.name }}</td>
             <td>{{ m_url.completion_pct|percentage:1 }}</td>
-            <td>{{ m_url.delay|duration|default:unknown }}</td>
+            <td>{{ m_url.delay|duration }}</td>
             <td>{{ m_url.duration_avg|floatvalue:2 }}</td>
             <td>{{ m_url.duration_stddev|floatvalue:2 }}</td>
             <td>{{ m_url.score|floatvalue:1|default:'∞' }}</td>


### PR DESCRIPTION
The filter was passed an undefined variable which caused the template to
be rendered as empty. Since the other table columns default to an empty
string instead of "unknown", simply remove the default:"unknown" filter.

Also correct a closing %} tag.