### PR TITLE
releng: Fix django warnings

### DIFF
--- a/packages/migrations/0003_auto_20170524_0704.py
+++ b/packages/migrations/0003_auto_20170524_0704.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('packages', '0002_auto_20160731_0556'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='flagrequest',
+            name='user_email',
+            field=models.EmailField(max_length=254, verbose_name=b'email address'),
+        ),
+    ]

--- a/releng/migrations/0004_auto_20170524_0704.py
+++ b/releng/migrations/0004_auto_20170524_0704.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('releng', '0003_release_populate_last_modified'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='test',
+            name='modules',
+            field=models.ManyToManyField(to='releng.Module', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='test',
+            name='rollback_modules',
+            field=models.ManyToManyField(related_name='rollback_test_set', to='releng.Module', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='test',
+            name='user_email',
+            field=models.EmailField(max_length=254, verbose_name=b'email address'),
+        ),
+    ]

--- a/releng/models.py
+++ b/releng/models.py
@@ -101,12 +101,12 @@ class Test(models.Model):
     source = models.ForeignKey(Source)
     clock_choice = models.ForeignKey(ClockChoice)
     filesystem = models.ForeignKey(Filesystem)
-    modules = models.ManyToManyField(Module, null=True, blank=True)
+    modules = models.ManyToManyField(Module, blank=True)
     bootloader = models.ForeignKey(Bootloader)
     rollback_filesystem = models.ForeignKey(Filesystem,
             related_name="rollback_test_set", null=True, blank=True)
     rollback_modules = models.ManyToManyField(Module,
-            related_name="rollback_test_set", null=True, blank=True)
+            related_name="rollback_test_set", blank=True)
 
     success = models.BooleanField(default=True)
     comments = models.TextField(null=True, blank=True)


### PR DESCRIPTION
Fixes warnings for releng.Test.modules and releng.Test.rollback_modules
(fields.W340) null has no effect on ManyToManyField.