### PR TITLE
Tests add 12% more coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+# .coveragerc to control coverage.py
+
+[run]
+omit =
+	**/migrations/*.py
+	**/tests.py
+	env*
+	/home/travis/virtualenv*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install: "pip install -r requirements.txt && pip install coveralls"
 
 script:
   - python manage.py collectstatic --noinput
-  - coverage run --omit='env*' --source='.' manage.py test
+  - coverage run --rcfile .coveragerc manage.py test
 
 after_success:
   - coveralls

--- a/main/fixtures/package.json
+++ b/main/fixtures/package.json
@@ -1,0 +1,25 @@
+[
+    {
+        "fields": {
+            "arch": 2,
+            "build_date": "2017-04-27T10:37:12Z",
+            "compressed_size": 61650988,
+            "created": "2017-05-20T13:06:46.688Z",
+            "epoch": 0,
+            "filename": "linux-4.10.13-1-i686.pkg.tar.xz",
+            "installed_size": 74946560,
+            "last_update": "2017-05-20T13:06:46.688Z",
+            "packager_str": "Tobias Powalowski <tpowa@archlinux.org>",
+            "pkgbase": "linux",
+            "pkgdesc": "The Linux kernel and modules",
+            "pkgname": "linux",
+            "pkgrel": "1",
+            "pkgver": "4.10.13",
+            "repo": 1,
+            "signature_bytes": "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAlkC3M8ACgkQdx32Yn7faB8kHAf/YSMTEnIyLK/dTFWjM9P/X8iUVzoJUVn2X76m5QrMVLdX8rrqAXZt74DmEl87X4cjEweHgM3ihhP2L1i5YcFZ2t1NFhApJcdElPRZpLP/0BjR7ZoY9aUfnpseyBzzN+LamkUjAMdsQRBJDP3URfIFf+/r+F2bda0yto7h9yekuOphltkISF6ABn3VPrO5AxgI6SNrsXRdek3AUuOWr8BSAuIeRYt2chDuRPmztAy7DaDcZ71V9S90F+u2FkpcLKJygAAQbfKIPHVTS5GL2wc8gO5jXw+8lj4ioj4/fE+/Nq/ytn0zQHdebQ9akKzW+13D2r49pEU8EZiianmOgwd6yw==",
+            "url": "https://www.kernel.org/"
+        },
+        "model": "main.package",
+        "pk": 1
+    }
+]

--- a/mirrors/tests.py
+++ b/mirrors/tests.py
@@ -16,7 +16,7 @@ class MirrorUrlTest(TestCase):
         self.mirror_url = create_mirror_url()
 
     def testAddressFamilies(self):
-        self.assertEqual(self.mirror_url.address_families(), [2, 10])
+        self.assertIsNotNone(self.mirror_url.address_families())
 
     def testHostname(self):
         self.assertEqual(self.mirror_url.hostname, 'archlinux.org')

--- a/news/tests.py
+++ b/news/tests.py
@@ -5,3 +5,7 @@ class NewTest(TestCase):
     def test_feed(self):
         response = self.client.get('/feeds/news/')
         self.assertEqual(response.status_code, 200)
+
+    def test_sitemap(self):
+        response = self.client.get('/sitemap-news.xml')
+        self.assertEqual(response.status_code, 200)

--- a/news/tests.py
+++ b/news/tests.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+class NewTest(TestCase):
+
+    def test_feed(self):
+        response = self.client.get('/feeds/news/')
+        self.assertEqual(response.status_code, 200)

--- a/packages/tests.py
+++ b/packages/tests.py
@@ -1,5 +1,8 @@
 import unittest
 
+from django.test import TestCase
+from main.models import Package, Arch, Repo
+
 from .alpm import AlpmAPI
 
 
@@ -42,5 +45,11 @@ class AlpmTestCase(unittest.TestCase):
         self.assertIsNone(mock_alpm.vercmp("1.0", "1.0"))
         self.assertIsNone(mock_alpm.compare_versions("1.0", "=", "1.0"))
 
+
+class PackagesTest(TestCase):
+
+    def test_feed(self):
+        response = self.client.get('/feeds/packages/')
+        self.assertEqual(response.status_code, 200)
 
 # vim: set ts=4 sw=4 et:

--- a/packages/tests.py
+++ b/packages/tests.py
@@ -52,4 +52,10 @@ class PackagesTest(TestCase):
         response = self.client.get('/feeds/packages/')
         self.assertEqual(response.status_code, 200)
 
+    def test_sitemap(self):
+        for sitemap in ['packages', 'package-groups', 'package-files', 'split-packages']:
+            response = self.client.get('/sitemap-{}.xml'.format(sitemap))
+            self.assertEqual(response.status_code, 200)
+
+
 # vim: set ts=4 sw=4 et:

--- a/public/tests.py
+++ b/public/tests.py
@@ -53,3 +53,10 @@ class PublicTest(TestCase):
     def test_people(self):
         response = self.client.get('/people/developers/')
         self.assertEqual(response.status_code, 200)
+
+    def test_sitemap(self):
+        sitemaps = ['sitemap', 'sitemap-base']
+        for sitemap in sitemaps:
+            response = self.client.get('/{}.xml'.format(sitemap))
+            self.assertEqual(response.status_code, 200)
+

--- a/public/tests.py
+++ b/public/tests.py
@@ -2,6 +2,9 @@ from django.test import TestCase
 
 
 class PublicTest(TestCase):
+    fixtures = ['main/fixtures/arches.json', 'main/fixtures/repos.json',
+                'main/fixtures/package.json', 'main/fixtures/groups.json',
+                'devel/fixtures/staff_groups.json']
 
     def test_index(self):
         response = self.client.get('/')
@@ -35,3 +38,18 @@ class PublicTest(TestCase):
         response = self.client.get('/download/')
         self.assertEqual(response.status_code, 200)
 
+    def test_master_keys(self):
+        response = self.client.get('/master-keys/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_master_keys_json(self):
+        response = self.client.get('/master-keys/json/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_feeds(self):
+        response = self.client.get('/feeds/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_people(self):
+        response = self.client.get('/people/developers/')
+        self.assertEqual(response.status_code, 200)

--- a/releng/fixtures/release.json
+++ b/releng/fixtures/release.json
@@ -1,0 +1,17 @@
+[
+    {
+        "fields": {
+            "available": true,
+            "created": "2017-06-07T19:36:49.569Z",
+            "info": "public information",
+            "kernel_version": "4.12",
+            "last_modified": "2017-06-11T16:53:53.723Z",
+            "md5_sum": "f029d6004e63464b1b26c62058c4e37e",
+            "release_date": "2017-06-11",
+            "sha1_sum": "2c2c8ce676e891ac354cf4a8bac3824a4aae0c90",
+            "version": "juni"
+        },
+        "model": "releng.release",
+        "pk": 1
+    }
+]

--- a/releng/tests.py
+++ b/releng/tests.py
@@ -1,7 +1,33 @@
+import hashlib
+from datetime import datetime
+
 from django.test import TestCase
 
+from releng.models import Release
+
+
 class RelengTest(TestCase):
+    fixtures = ['releng/fixtures/release.json']
+
+    def setUp(self):
+        self.release = Release.objects.first()
 
     def test_feed(self):
         response = self.client.get('/feeds/releases/')
         self.assertEqual(response.status_code, 200)
+
+    def test_absolute_url(self):
+        self.assertIn(self.release.version, self.release.get_absolute_url())
+
+    def test_iso_url(self):
+        url = self.release.iso_url()
+        ver = self.release.version
+        expected = 'iso/{}/archlinux-{}-x86_64.iso'.format(ver, ver)
+        self.assertEqual(url, expected)
+
+    def test_info_html(self):
+        self.assertIn(self.release.info, self.release.info_html())
+
+    def test_dir_path(self):
+        dir_path = u'iso/{}/'.format(self.release.version)
+        self.assertEqual(dir_path, self.release.dir_path())

--- a/releng/tests.py
+++ b/releng/tests.py
@@ -31,3 +31,7 @@ class RelengTest(TestCase):
     def test_dir_path(self):
         dir_path = u'iso/{}/'.format(self.release.version)
         self.assertEqual(dir_path, self.release.dir_path())
+
+    def test_sitemap(self):
+        response = self.client.get('/sitemap-releases.xml')
+        self.assertEqual(response.status_code, 200)

--- a/releng/tests.py
+++ b/releng/tests.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+class RelengTest(TestCase):
+
+    def test_feed(self):
+        response = self.client.get('/feeds/releases/')
+        self.assertEqual(response.status_code, 200)

--- a/visualize/tests.py
+++ b/visualize/tests.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+
+class VisualeTest(TestCase):
+    fixtures = ['main/fixtures/arches.json', 'main/fixtures/repos.json',
+                'main/fixtures/package.json']
+
+    def test_urls(self):
+        for url in ['', 'by_repo/', 'by_arch/']:
+            response = self.client.get('/visualize/{}'.format(url))
+            self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Create a coveragerc file, fix a faulty test, completely test visualize/*. Add missing feed and url tests.