### PR TITLE
Revert "dev dashboard: highlight table rows on mouse hover"

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -983,12 +983,6 @@ table td.country {
     width: auto;
 }
 
-/* dev: dashboard: dashboard and stats area */
-#dev-dashboard,
-#stats-area tr:hover {
-    background: #ffd;
-}
-
 /* dev dashboard: flagged packages */
 #dash-pkg-notify {
     text-align: right;


### PR DESCRIPTION
Reverts archlinux/archweb#37 (to address the "Developer Dashboard" becoming yellow).