### PR TITLE
dev dashboard: highlight table rows on mouse hover, second try

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -983,6 +983,12 @@ table td.country {
     width: auto;
 }
 
+/* dev: dashboard: dashboard and stats area */
+#dev-dashboard tr:hover,
+#stats-area tr:hover {
+    background: #ffd;
+}
+
 /* dev dashboard: flagged packages */
 #dash-pkg-notify {
     text-align: right;


### PR DESCRIPTION
Commit 73c6ac09ae3080791219b3b3bb31cffb20b82e53 ("dev dashboard: highlight
table rows on mouse hover") colored the complete dev dashboard in yellow,
this was reverted by d4cd8a2396a475f08ddc6aff2f8ecd4caca8c313 ("Revert
"dev dashboard: highlight table rows on mouse hover"").

Try again with fixed CSS.