### PR TITLE
Add setup.cfg with pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = settings
+
+# Cope with tests.py files in separate subdirs.
+python_files = tests.py
+testpaths = devel main mirrors news packages public releng retro visualize


### PR DESCRIPTION
This allows for using pytest easily, after installing it (and
pytest-django).

TODO:
- [ ] update after/for https://github.com/archlinux/archweb/pull/48#issuecomment-312925869