### PR TITLE
Remove CDN configuration option

### DIFF
--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -53,7 +53,4 @@ MEDIA_URL = '/media/img/'
 ## Make this unique, and don't share it with anybody.
 SECRET_KEY = '00000000000000000000000000000000000000000000000'
 
-## CDN settings
-CDN_ENABLED = False
-
 # vim: set ts=4 sw=4 et:

--- a/main/templatetags/cdn.py
+++ b/main/templatetags/cdn.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 register = template.Library()
@@ -8,13 +7,8 @@ register = template.Library()
 @register.simple_tag
 def jquery():
     version = '1.8.3'
-    oncdn = getattr(settings, 'CDN_ENABLED', True)
-    if oncdn:
-        link = 'https://ajax.googleapis.com/ajax/libs/jquery/' \
-                '%s/jquery.min.js' % version
-    else:
-        filename = 'jquery-%s.min.js' % version
-        link = staticfiles_storage.url(filename)
+    filename = 'jquery-%s.min.js' % version
+    link = staticfiles_storage.url(filename)
     return '<script type="text/javascript" src="%s"></script>' % link
 
 


### PR DESCRIPTION
Remove the unused CDN configuration option for JQuery.

Signed-off-by: Jelle van der Waa <jelle@vdwaa.nl>