### PR TITLE
Fix the HTTP error 500 when trying to access the admin_log page.

### DIFF
--- a/devel/views.py
+++ b/devel/views.py
@@ -262,7 +262,7 @@ def admin_log(request, username=None):
     if username:
         user = get_object_or_404(User, username=username)
     context = {'title': "Admin Action Log", 'log_user': user, }
-    context.update(admin.site.each_context())
+    context.update(admin.site.each_context(request))
     return render(request, 'devel/admin_log.html', context)
 
 # vim: set ts=4 sw=4 et:


### PR DESCRIPTION
When trying to access the admin_log page from Django admin, there
was missing the request from the each_context call.