### PR TITLE
Added removed rss

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ packages, you will probably want the following:
 Alter architecture and repo to get x86\_64 and packages from other repos if
 needed.
 
+8. Database Updates for Added/Removed packages
+
+        sqlite3 archweb.db < packages/sql/update.sqlite3.sql
+
+For PostgreSQL use packages/sql/update.postgresql_psycopg2.sql
+
+
 # Testing SMTP server
 
 To be able to create an account on your test environment an SMTP server is

--- a/feeds.py
+++ b/feeds.py
@@ -47,9 +47,10 @@ class FasterRssFeed(Rss201rev2Feed):
 
 
 def package_last_modified(request, *args, **kwargs):
-    cursor = connection.cursor()
-    cursor.execute("SELECT MAX(last_update) FROM packages")
-    return cursor.fetchone()[0]
+    try:
+        return Package.objects.latest('last_update').last_update
+    except ObjectDoesNotExist:
+        return
 
 
 class PackageFeed(Feed):

--- a/packages/models.py
+++ b/packages/models.py
@@ -338,6 +338,10 @@ class Update(models.Model):
             pkgs = pkgs.filter(arch__in=arches)
         return pkgs
 
+    def get_absolute_url(self):
+        return '/packages/%s/%s/%s/' % (self.repo.name.lower(),
+                self.arch.name, self.pkgname)
+
     def __unicode__(self):
         return u'%s of %s on %s' % (self.get_action_flag_display(),
                 self.pkgname, self.created)

--- a/templates/public/feeds.html
+++ b/templates/public/feeds.html
@@ -59,6 +59,68 @@
     <p>A <a href="https://aur.archlinux.org/rss/" class="rss" title="AUR newest packages feed">newest packages feed</a>
     is also available from the <a href="https://aur.archlinux.org/" title="AUR Homepage">Arch User Repository (AUR)</a>.</p>
 
+    <p>Recently added packages.</p>
+    <table class="pretty2">
+        <thead>
+            <tr>
+                <th></th>
+                <th>All Arches</th>
+                {% for arch in arches %}
+                <th>{{ arch }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>All Repos</strong></td>
+                <td><a href="/feeds/packages/added/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/added/{{ arch }}/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            {% for repo in repos %}
+            <tr>
+                <td><strong>{{ repo }}</strong></td>
+                <td><a href="/feeds/packages/added/all/{{ repo|lower }}/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/added/{{ arch }}/{{ repo|lower }}/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <p>Recently removed packages.</p>
+    <table class="pretty2">
+        <thead>
+            <tr>
+                <th></th>
+                <th>All Arches</th>
+                {% for arch in arches %}
+                <th>{{ arch }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>All Repos</strong></td>
+                <td><a href="/feeds/packages/removed/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/removed/{{ arch }}/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            {% for repo in repos %}
+            <tr>
+                <td><strong>{{ repo }}</strong></td>
+                <td><a href="/feeds/packages/removed/all/{{ repo|lower }}/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/removed/{{ arch }}/{{ repo|lower }}/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
     <h3>Release Feed</h3>
 
     <p>Grab the <a href="/feeds/releases/" class="rss" title="Arch Linux release feed">ISO release feed</a>

--- a/urls.py
+++ b/urls.py
@@ -6,7 +6,7 @@ from django.contrib.auth import views as auth_views
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 
-from feeds import PackageFeed, NewsFeed, ReleaseFeed
+from feeds import PackageFeed, NewsFeed, ReleaseFeed, PackageUpdatesFeed
 import sitemaps
 
 import devel.urls
@@ -54,6 +54,10 @@ feeds_patterns = [
     url(r'^$', public.views.feeds, name='feeds-list'),
     url(r'^news/$', cache_page(311)(NewsFeed())),
     url(r'^packages/$', cache_page(313)(PackageFeed())),
+    url(r'^packages/(added|removed)/$', cache_page(313)(PackageUpdatesFeed())),
+    url(r'^packages/(added|removed)/(?P<arch>[A-z0-9]+)/$', cache_page(313)(PackageUpdatesFeed())),
+    url(r'^packages/(added|removed)/all/(?P<repo>[A-z0-9\-]+)/$', cache_page(313)(PackageUpdatesFeed())),
+    url(r'^packages/(added|removed)/(?P<arch>[A-z0-9]+)/(?P<repo>[A-z0-9\-]+)/$', cache_page(313)(PackageUpdatesFeed())),
     url(r'^packages/(?P<arch>[A-z0-9]+)/$', cache_page(313)(PackageFeed())),
     url(r'^packages/all/(?P<repo>[A-z0-9\-]+)/$', cache_page(313)(PackageFeed())),
     url(r'^packages/(?P<arch>[A-z0-9]+)/(?P<repo>[A-z0-9\-]+)/$', cache_page(313)(PackageFeed())),


### PR DESCRIPTION
This PR adds two feeds, one for newly added packages (which did not exists in the repo before) and removed packages. This requires triggers to be configured in your database for updates. For SQLite they are not setup for some reason by default? Is it possible we can make this happen? @angvp @grazzolini? Then we can at least right some tests.

The triggers can be found in packages/sql. packages/sql/update.sqlite3.sql for sqlite and packages/sql/update.postgresql_psycopg2.sql for PostgreSQL which seems to be enabled and working in production! 👍 

