### PR TITLE
packages/admin: Fix the syntax for queryset

### DIFF
--- a/packages/admin.py
+++ b/packages/admin.py
@@ -20,7 +20,7 @@ class FlagRequestAdmin(admin.ModelAdmin):
     ordering = ('-created',)
 
     def get_queryset(self, request):
-        qs = super(FlagRequestAdmin, self).queryset(request)
+        qs = super(FlagRequestAdmin, self).get_queryset(request)
         return qs.select_related('repo', 'user')
 
 
@@ -40,7 +40,7 @@ class SignoffSpecificationAdmin(admin.ModelAdmin):
     ordering = ('-created',)
 
     def get_queryset(self, request):
-        qs = super(SignoffSpecificationAdmin, self).queryset(request)
+        qs = super(SignoffSpecificationAdmin, self).get_queryset(request)
         return qs.select_related('arch', 'repo', 'user')
 
 


### PR DESCRIPTION
Django 1.7 changed the method name to get_queryset.