### PR TITLE
package details: remove category from bugtracker links

### DIFF
--- a/main/templatetags/details_link.py
+++ b/main/templatetags/details_link.py
@@ -32,7 +32,6 @@ def bugs_list(package):
     url = "https://bugs.archlinux.org/"
     data = {
         'project': package.repo.bugs_project,
-        'cat[]': package.repo.bugs_category,
         'string': package.pkgname,
     }
     return link_encode(url, data)


### PR DESCRIPTION
This completely screws up searching for bugs, as you can easily miss any
bugs filed to the testing package, and will *always* miss the ones that
have been moved to "Upstream Bugs".

There is no purpose in restricting the view of bugs filed against a
specific package, to some arbitrary subcategory of "why" the bug was
filed; all it accomplishes is causing unknowing users to file duplicate
bug reports.