### PR TITLE
Return different dep types under different keys in JSON results

### DIFF
--- a/packages/utils.py
+++ b/packages/utils.py
@@ -472,6 +472,9 @@ def get_signoff_groups(repos=None, user=None):
     return signoff_groups
 
 
+DEPENDENCY_TYPES =  [('D', 'depends'), ('O', 'optdepends'),
+                     ('M', 'makedepends'), ('C', 'checkdepends')]
+
 class PackageJSONEncoder(DjangoJSONEncoder):
     pkg_attributes = ['pkgname', 'pkgbase', 'repo', 'arch', 'pkgver',
             'pkgrel', 'epoch', 'pkgdesc', 'url', 'filename', 'compressed_size',
@@ -489,8 +492,7 @@ class PackageJSONEncoder(DjangoJSONEncoder):
             for attr in self.pkg_list_attributes:
                 data[attr] = getattr(obj, attr).all()
             all_deps = obj.depends.all()
-            for (deptype, name) in [('D', 'depends'), ('O', 'optdepends'),
-                                    ('M', 'makedepends'), ('C', 'checkdepends')]:
+            for (deptype, name) in DEPENDENCY_TYPES:
                 data[name] = all_deps.filter(deptype=deptype)
             return data
         if isinstance(obj, PackageFile):

--- a/packages/utils.py
+++ b/packages/utils.py
@@ -478,7 +478,7 @@ class PackageJSONEncoder(DjangoJSONEncoder):
             'installed_size', 'build_date', 'last_update', 'flag_date',
             'maintainers', 'packager']
     pkg_list_attributes = ['groups', 'licenses', 'conflicts',
-            'provides', 'replaces', 'depends']
+            'provides', 'replaces']
 
     def default(self, obj):
         if hasattr(obj, '__iter__'):
@@ -488,6 +488,10 @@ class PackageJSONEncoder(DjangoJSONEncoder):
             data = {attr: getattr(obj, attr) for attr in self.pkg_attributes}
             for attr in self.pkg_list_attributes:
                 data[attr] = getattr(obj, attr).all()
+            all_deps = obj.depends.all()
+            for (deptype, name) in [('D', 'depends'), ('O', 'optdepends'),
+                                    ('M', 'makedepends'), ('C', 'checkdepends')]:
+                data[name] = all_deps.filter(deptype=deptype)
             return data
         if isinstance(obj, PackageFile):
             filename = obj.filename or ''


### PR DESCRIPTION
Currently all dependencies are under the same `depends` key in the JSON results.  With this commit they're instead sorted under keys for each dependency type instead.