### PR TITLE
Bump results limit of search json view to 1000

### DIFF
--- a/packages/tests.py
+++ b/packages/tests.py
@@ -67,7 +67,6 @@ class PackageSearchJson(TestCase):
         response = self.client.get('/packages/search/json/')
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)
-        self.assertEqual(data['limit'], 250)
         self.assertEqual(data['results'], [])
         self.assertEqual(data['valid'], False)
 

--- a/packages/views/search.py
+++ b/packages/views/search.py
@@ -1,6 +1,7 @@
 import json
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import Q
 from django.http import HttpResponse
@@ -142,11 +143,9 @@ class SearchListView(ListView):
 
 
 def search_json(request):
-    limit = 1000
-
     container = {
         'version': 2,
-        'limit': limit,
+        'limit': settings.JSON_RESULTS_LIMIT,
         'valid': False,
         'results': [],
     }

--- a/packages/views/search.py
+++ b/packages/views/search.py
@@ -142,7 +142,7 @@ class SearchListView(ListView):
 
 
 def search_json(request):
-    limit = 250
+    limit = 1000
 
     container = {
         'version': 2,

--- a/settings.py
+++ b/settings.py
@@ -164,6 +164,9 @@ DATABASES = {
     },
 }
 
+# Limit resulted JSON results
+JSON_RESULTS_LIMIT = 1000
+
 # Import local settings
 try:
     from local_settings import *


### PR DESCRIPTION
This is for my completely selfish reasons, but it makes no sense to limit the results while there's no pagination for it.