### PR TITLE
mirrors/views/api: Fix mirrors.change_mirror perm typo

### DIFF
--- a/mirrors/views/api.py
+++ b/mirrors/views/api.py
@@ -94,7 +94,7 @@ def mirror_details_json(request, name):
     data = status_info.copy()
     data['version'] = 4
     data['details'] = mirror.get_full_url()
-    if authorized and request.user.has_perm('mirror.change_mirror'):
+    if authorized and request.user.has_perm('mirrors.change_mirror'):
         data['admin_email'] = mirror.admin_email
         data['alternate_email'] = mirror.alternate_email
     to_json = json.dumps(data, ensure_ascii=False,


### PR DESCRIPTION
(Of course I catch this *after* it's already been deployed, but at least it doesn't break anything that already worked.)