### PR TITLE
FS#50516: mirrors: Extend /mirrors/status/json/

### DIFF
--- a/mirrors/views/api.py
+++ b/mirrors/views/api.py
@@ -27,6 +27,8 @@ class MirrorStatusJSONEncoder(DjangoJSONEncoder):
             data['country'] = unicode(country.name)
             data['country_code'] = country.code
             data['isos'] = obj.mirror.isos
+            data['ipv4'] = obj.has_ipv4
+            data['ipv6'] = obj.has_ipv6
             data['details'] = obj.get_full_url()
             return data
         if isinstance(obj, MirrorProtocol):


### PR DESCRIPTION
Add the ipv4/ipv6 availability to the /mirrors/status/json api.
See https://bugs.archlinux.org/task/50516