### PR TITLE
public: Add vagrant image link to download page

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -72,6 +72,13 @@
             title="Arch Linux Netboot">Arch Linux Netboot</a></li>
     </ul>
 
+    <h3>Vagrant images</h3>
+
+    <p>Vagrant images for libvirt and virtualbox are available on the <a href="https://app.vagrantup.com/archlinux/boxes/archlinux">Vagrant Cloud</a>. You can bootstrap the image with the following commands:</p>
+    <code>vagrant init archlinux/archlinux</code>
+    </br>
+    <code>vagrant up</code>
+
     <h3>HTTP Direct Downloads</h3>
 
     <p>In addition to the BitTorrent links above, install images can also be


### PR DESCRIPTION
Mention the official Vagrant image on the download page and where to
find it.

This PR needs a rebase first.