### PR TITLE
Fix the StaffGroup query

### DIFF
--- a/devel/models.py
+++ b/devel/models.py
@@ -56,7 +56,7 @@ class UserProfile(models.Model):
 
     def get_absolute_url(self):
         user = self.user
-        group = StaffGroup.objects.filter(group=user.groups.all()).first()
+        group = StaffGroup.objects.filter(group=user.groups.all().first()).get()
         if group:
             return '%s#%s' % (group.get_absolute_url(), user.username)
         return None


### PR DESCRIPTION
Due to changes to Django 1.11, this didn't return the object. Fix to get the object instead
of the queryset.