### PR TITLE
Fix unit test warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 cache: pip
 install: "pip install -r requirements.txt && pip install coveralls pylint"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.6"
-  - "3.7"
 cache: pip
 install: "pip install -r requirements.txt && pip install coveralls pylint"
 

--- a/packages/utils.py
+++ b/packages/utils.py
@@ -78,7 +78,7 @@ def get_split_packages_info():
     pkgnames = Package.objects.values('pkgname')
     split_pkgs = Package.objects.exclude(pkgname=F('pkgbase')).exclude(
             pkgbase__in=pkgnames).values('pkgbase', 'repo', 'arch').annotate(
-            last_update=Max('last_update')).order_by().distinct()
+            last_update=Max('last_update')).distinct()
     all_arches = Arch.objects.in_bulk({s['arch'] for s in split_pkgs})
     all_repos = Repo.objects.in_bulk({s['repo'] for s in split_pkgs})
     for split in split_pkgs:

--- a/sitemaps.py
+++ b/sitemaps.py
@@ -16,7 +16,7 @@ class PackagesSitemap(Sitemap):
         return Package.objects.normal().only(
                 'pkgname', 'last_update', 'files_last_update',
                 'repo__name', 'repo__testing', 'repo__staging',
-                'arch__name').order_by()
+                'arch__name')
 
     def lastmod(self, obj):
         return obj.last_update
@@ -81,7 +81,7 @@ class NewsSitemap(Sitemap):
         self.one_week_ago = now - timedelta(days=7)
 
     def items(self):
-        return News.objects.all().defer('content', 'guid', 'title').order_by()
+        return News.objects.all().defer('content', 'guid', 'title')
 
     def lastmod(self, obj):
         return obj.last_modified
@@ -110,7 +110,7 @@ class ReleasesSitemap(Sitemap):
     changefreq = "monthly"
 
     def items(self):
-        return Release.objects.all().defer('info', 'torrent_data').order_by()
+        return Release.objects.all().defer('info', 'torrent_data')
 
     def lastmod(self, obj):
         return obj.last_modified
@@ -129,7 +129,7 @@ class TodolistSitemap(Sitemap):
         self.two_weeks_ago = now - timedelta(days=14)
 
     def items(self):
-        return Todolist.objects.all().defer('raw').order_by()
+        return Todolist.objects.all().defer('raw').order_by('created')
 
     def lastmod(self, obj):
         return obj.last_modified


### PR DESCRIPTION
Fix unit test warnings due to Paginators requiring specified ordering when rendering sitemaps. These were caused by calling order_by() without any parameters, which removes all ordering, even if specified at the entity level via Meta.