### PR TITLE
todolists: Add json endpoint for todo detail view

### DIFF
--- a/todolists/tests/test_views.py
+++ b/todolists/tests/test_views.py
@@ -27,3 +27,9 @@ class TestTodolist(TestCase):
         response = self.client.get(self.todolist.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.todolist.name, response.content)
+
+    def test_todolist_json(self):
+        response = self.client.get(self.todolist.get_absolute_url() + 'json')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['name'], self.todolist.name)

--- a/todolists/urls.py
+++ b/todolists/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from django.contrib.auth.decorators import permission_required
 
-from .views import (view_redirect, view, add, edit, flag,
+from .views import (view_redirect, view, view_json, add, edit, flag,
         list_pkgbases, DeleteTodolist, TodolistListView)
 
 urlpatterns = [
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r'^add/$',
         permission_required('todolists.add_todolist')(add)),
     url(r'^(?P<slug>[-\w]+)/$', view),
+    url(r'^(?P<slug>[-\w]+)/json$', view_json),
     url(r'^(?P<slug>[-\w]+)/edit/$',
         permission_required('todolists.change_todolist')(edit)),
     url(r'^(?P<slug>[-\w]+)/delete/$',


### PR DESCRIPTION
Add a /todo/$name/json endpoint which returns the json for a todo list
item.