### PR TITLE
todolists: remove old_id from todolist model

### DIFF
--- a/todolists/models.py
+++ b/todolists/models.py
@@ -9,7 +9,6 @@ from main.utils import set_created_field
 
 class Todolist(models.Model):
     slug = models.SlugField(max_length=255, unique=True)
-    old_id = models.IntegerField(null=True, unique=True)
     name = models.CharField(max_length=255)
     description = models.TextField()
     creator = models.ForeignKey(User, on_delete=models.PROTECT,

--- a/todolists/urls.py
+++ b/todolists/urls.py
@@ -1,14 +1,11 @@
 from django.conf.urls import url
 from django.contrib.auth.decorators import permission_required
 
-from .views import (view_redirect, view, view_json, add, edit, flag,
+from .views import (view, view_json, add, edit, flag,
         list_pkgbases, DeleteTodolist, TodolistListView)
 
 urlpatterns = [
     url(r'^$', TodolistListView.as_view(), name='todolist-list'),
-
-    # old todolists URLs, permanent redirect view so we don't break all links
-    url(r'^(?P<old_id>\d+)/$', view_redirect),
 
     url(r'^add/$',
         permission_required('todolists.add_todolist')(add)),

--- a/todolists/views.py
+++ b/todolists/views.py
@@ -57,11 +57,6 @@ def flag(request, slug, pkg_id):
     return redirect(todolist)
 
 
-def view_redirect(request, old_id):
-    todolist = get_object_or_404(Todolist, old_id=old_id)
-    return redirect(todolist, permanent=True)
-
-
 def view(request, slug):
     todolist = get_object_or_404(Todolist, slug=slug)
     svn_roots = Repo.objects.values_list(


### PR DESCRIPTION
Old todolist items contained an old_id to keep links working, these
items where most recenlty created 6 years ago. Since old todolists of a
long time ago aren't particularly interesting they will be removed.

Closes #141