### PR TITLE
Fix Foreignkey implicit on_delete on django < 2.0

### DIFF
--- a/devel/models.py
+++ b/devel/models.py
@@ -42,7 +42,7 @@ class UserProfile(models.Model):
     favorite_distros = models.CharField(max_length=255, null=True, blank=True)
     picture = models.FileField(upload_to='devs', default='devs/silhouette.png',
         help_text="Ideally 125px by 125px")
-    user = models.OneToOneField(User, related_name='userprofile')
+    user = models.OneToOneField(User, related_name='userprofile', on_delete=models.CASCADE)
     allowed_repos = models.ManyToManyField('main.Repo', blank=True)
     latin_name = models.CharField(max_length=255, null=True, blank=True,
         help_text="Latin-form name; used only for non-Latin full names")
@@ -65,7 +65,7 @@ class UserProfile(models.Model):
 class StaffGroup(models.Model):
     name = models.CharField(max_length=100)
     slug = models.SlugField(max_length=100, unique=True)
-    group = models.OneToOneField(Group)
+    group = models.OneToOneField(Group, on_delete=models.CASCADE)
     sort_order = models.PositiveIntegerField()
     member_title = models.CharField(max_length=100)
     description = models.TextField(blank=True)
@@ -82,9 +82,9 @@ class StaffGroup(models.Model):
 
 class MasterKey(models.Model):
     owner = models.ForeignKey(User, related_name='masterkey_owner',
-        help_text="The developer holding this master key")
+        help_text="The developer holding this master key", on_delete=models.CASCADE)
     revoker = models.ForeignKey(User, related_name='masterkey_revoker',
-        help_text="The developer holding the revocation certificate")
+        help_text="The developer holding the revocation certificate", on_delete=models.CASCADE)
     pgp_key = PGPKeyField(max_length=40, verbose_name="PGP key fingerprint",
         help_text="consists of 40 hex digits; use `gpg --fingerprint`")
     created = models.DateField()
@@ -101,7 +101,7 @@ class MasterKey(models.Model):
 
 class DeveloperKey(models.Model):
     owner = models.ForeignKey(User, related_name='all_keys', null=True,
-            help_text="The developer this key belongs to")
+            help_text="The developer this key belongs to", on_delete=models.CASCADE)
     key = PGPKeyField(max_length=40, verbose_name="PGP key fingerprint",
             unique=True)
     created = models.DateTimeField()

--- a/main/models.py
+++ b/main/models.py
@@ -430,7 +430,7 @@ class Package(models.Model):
 
 
 class PackageFile(models.Model):
-    pkg = models.ForeignKey(Package)
+    pkg = models.ForeignKey(Package, on_delete=models.CASCADE)
     is_directory = models.BooleanField(default=False)
     directory = models.CharField(max_length=1024)
     filename = models.CharField(max_length=1024, null=True, blank=True)

--- a/mirrors/models.py
+++ b/mirrors/models.py
@@ -71,7 +71,7 @@ class MirrorUrl(models.Model):
     url = models.CharField("URL", max_length=255, unique=True)
     protocol = models.ForeignKey(MirrorProtocol, related_name="urls",
             editable=False, on_delete=models.PROTECT)
-    mirror = models.ForeignKey(Mirror, related_name="urls")
+    mirror = models.ForeignKey(Mirror, related_name="urls", on_delete=models.CASCADE)
     country = CountryField(blank=True, db_index=True)
     has_ipv4 = models.BooleanField("IPv4 capable", default=True,
             editable=False)
@@ -124,7 +124,7 @@ class MirrorUrl(models.Model):
 class MirrorRsync(models.Model):
     # max length is 40 chars for full-form IPv6 addr + subnet
     ip = IPNetworkField("IP")
-    mirror = models.ForeignKey(Mirror, related_name="rsync_ips")
+    mirror = models.ForeignKey(Mirror, related_name="rsync_ips", on_delete=models.CASCADE)
     created = models.DateTimeField(editable=False)
 
     def __unicode__(self):
@@ -165,8 +165,8 @@ class CheckLocation(models.Model):
 
 
 class MirrorLog(models.Model):
-    url = models.ForeignKey(MirrorUrl, related_name="logs")
-    location = models.ForeignKey(CheckLocation, related_name="logs", null=True)
+    url = models.ForeignKey(MirrorUrl, related_name="logs", on_delete=models.CASCADE)
+    location = models.ForeignKey(CheckLocation, related_name="logs", null=True, on_delete=models.CASCADE)
     check_time = models.DateTimeField(db_index=True)
     last_sync = models.DateTimeField(null=True)
     duration = models.FloatField(null=True)

--- a/packages/models.py
+++ b/packages/models.py
@@ -24,7 +24,7 @@ class PackageRelation(models.Model):
             (WATCHER, 'Watcher'),
     )
     pkgbase = models.CharField(max_length=255)
-    user = models.ForeignKey(User, related_name="package_relations")
+    user = models.ForeignKey(User, related_name="package_relations", on_delete=models.CASCADE)
     type = models.PositiveIntegerField(choices=TYPE_CHOICES, default=MAINTAINER)
     created = models.DateTimeField(editable=False)
 
@@ -77,9 +77,9 @@ class SignoffSpecification(models.Model):
     pkgver = models.CharField(max_length=255)
     pkgrel = models.CharField(max_length=255)
     epoch = models.PositiveIntegerField(default=0)
-    arch = models.ForeignKey(Arch)
-    repo = models.ForeignKey(Repo)
-    user = models.ForeignKey(User, null=True)
+    arch = models.ForeignKey(Arch, on_delete=models.CASCADE)
+    repo = models.ForeignKey(Repo, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, null=True, on_delete=models.CASCADE)
     created = models.DateTimeField(editable=False)
     required = models.PositiveIntegerField(default=2,
         help_text="How many signoffs are required for this package?")
@@ -145,9 +145,9 @@ class Signoff(models.Model):
     pkgver = models.CharField(max_length=255)
     pkgrel = models.CharField(max_length=255)
     epoch = models.PositiveIntegerField(default=0)
-    arch = models.ForeignKey(Arch)
-    repo = models.ForeignKey(Repo)
-    user = models.ForeignKey(User, related_name="package_signoffs")
+    arch = models.ForeignKey(Arch, on_delete=models.CASCADE)
+    repo = models.ForeignKey(Repo, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, related_name="package_signoffs", on_delete=models.CASCADE)
     created = models.DateTimeField(editable=False, db_index=True)
     revoked = models.DateTimeField(null=True)
     comments = models.TextField(null=True, blank=True)
@@ -178,7 +178,7 @@ class FlagRequest(models.Model):
     '''
     A notification the package is out-of-date submitted through the web site.
     '''
-    user = models.ForeignKey(User, blank=True, null=True)
+    user = models.ForeignKey(User, blank=True, null=True, on_delete=models.CASCADE)
     user_email = models.EmailField('email address')
     created = models.DateTimeField(editable=False, db_index=True)
     ip_address = models.GenericIPAddressField('IP address', unpack_ipv4=True)
@@ -186,7 +186,7 @@ class FlagRequest(models.Model):
     pkgver = models.CharField(max_length=255)
     pkgrel = models.CharField(max_length=255)
     epoch = models.PositiveIntegerField(default=0)
-    repo = models.ForeignKey(Repo)
+    repo = models.ForeignKey(Repo, on_delete=models.CASCADE)
     num_packages = models.PositiveIntegerField('number of packages', default=1)
     message = models.TextField('message to developer', blank=True)
     is_spam = models.BooleanField(default=False,
@@ -278,8 +278,8 @@ class Update(models.Model):
 
     package = models.ForeignKey(Package, related_name="updates",
             null=True, on_delete=models.SET_NULL)
-    repo = models.ForeignKey(Repo, related_name="updates")
-    arch = models.ForeignKey(Arch, related_name="updates")
+    repo = models.ForeignKey(Repo, related_name="updates", on_delete=models.CASCADE)
+    arch = models.ForeignKey(Arch, related_name="updates", on_delete=models.CASCADE)
     pkgname = models.CharField(max_length=255, db_index=True)
     pkgbase = models.CharField(max_length=255)
     action_flag = models.PositiveSmallIntegerField('action flag',
@@ -352,7 +352,7 @@ class PackageGroup(models.Model):
     Represents a group a package is in. There is no actual group entity,
     only names that link to given packages.
     '''
-    pkg = models.ForeignKey(Package, related_name='groups')
+    pkg = models.ForeignKey(Package, related_name='groups', on_delete=models.CASCADE)
     name = models.CharField(max_length=255, db_index=True)
 
     def __unicode__(self):
@@ -363,7 +363,7 @@ class PackageGroup(models.Model):
 
 
 class License(models.Model):
-    pkg = models.ForeignKey(Package, related_name='licenses')
+    pkg = models.ForeignKey(Package, related_name='licenses', on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
 
     def __unicode__(self):
@@ -473,7 +473,7 @@ class Depend(RelatedToBase):
         ('C', 'Check Depend'),
     )
 
-    pkg = models.ForeignKey(Package, related_name='depends')
+    pkg = models.ForeignKey(Package, related_name='depends', on_delete=models.CASCADE)
     comparison = models.CharField(max_length=255, default='')
     description = models.TextField(null=True, blank=True)
     deptype = models.CharField(max_length=1, default='D',
@@ -488,12 +488,12 @@ class Depend(RelatedToBase):
 
 
 class Conflict(RelatedToBase):
-    pkg = models.ForeignKey(Package, related_name='conflicts')
+    pkg = models.ForeignKey(Package, related_name='conflicts', on_delete=models.CASCADE)
     comparison = models.CharField(max_length=255, default='')
 
 
 class Provision(RelatedToBase):
-    pkg = models.ForeignKey(Package, related_name='provides')
+    pkg = models.ForeignKey(Package, related_name='provides', on_delete=models.CASCADE)
     # comparison must be '=' for provides
 
     @property
@@ -504,7 +504,7 @@ class Provision(RelatedToBase):
 
 
 class Replacement(RelatedToBase):
-    pkg = models.ForeignKey(Package, related_name='replaces')
+    pkg = models.ForeignKey(Package, related_name='replaces', on_delete=models.CASCADE)
     comparison = models.CharField(max_length=255, default='')
 
 

--- a/todolists/models.py
+++ b/todolists/models.py
@@ -54,12 +54,12 @@ class TodolistPackage(models.Model):
         (IN_PROGRESS, 'In-progress'),
     )
 
-    todolist = models.ForeignKey(Todolist)
+    todolist = models.ForeignKey(Todolist, on_delete=models.CASCADE)
     pkg = models.ForeignKey(Package, null=True, on_delete=models.SET_NULL)
     pkgname = models.CharField(max_length=255)
     pkgbase = models.CharField(max_length=255)
-    arch = models.ForeignKey(Arch)
-    repo = models.ForeignKey(Repo)
+    arch = models.ForeignKey(Arch, on_delete=models.CASCADE)
+    repo = models.ForeignKey(Repo, on_delete=models.CASCADE)
     created = models.DateTimeField(editable=False)
     last_modified = models.DateTimeField(editable=False)
     removed = models.DateTimeField(null=True, blank=True)


### PR DESCRIPTION
Foreignkey used to implicitly be on_delete=models.CASCADE and has to be
explicit now.