### PR TITLE
templates/public/about: remove unsupported section

### DIFF
--- a/templates/public/about.html
+++ b/templates/public/about.html
@@ -27,9 +27,9 @@ contribution.
 The minimal Arch base package set resides in the streamlined [core] repository.
 In addition, the official [extra], [community], and [testing] repositories
 provide several thousand high-quality, packages to meet your software demands.
-Arch also offers an [unsupported] section in the Arch Linux User Repository
-(AUR), which contains over 9,000 build scripts, for compiling installable
-packages from source using the Arch Linux makepkg application.
+Arch also offers the Arch Linux User Repository (AUR), which contains more than
+49,000 build scripts, for compiling installable packages from source using the
+Arch Linux makepkg application.
 </p>
 <p>
 Arch Linux uses a "rolling release" system which allows one-time installation


### PR DESCRIPTION
The [unsupported] section blurb was outdated in both its existence and
the fact that there are almost 50k PKGBUILDs inside of it as of $DATE.