### PR TITLE
[donotmerge] Unify command logging

### DIFF
--- a/devel/management/commands/generate_keyring.py
+++ b/devel/management/commands/generate_keyring.py
@@ -7,20 +7,12 @@ Assemble a GPG keyring with all known developer keys.
 Usage: ./manage.py generate_keyring <keyserver> <keyring_path>
 """
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import CommandError
 
-import logging
 import subprocess
-import sys
 
+from main.management.command import BaseCommand
 from devel.models import MasterKey, UserProfile
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s -> %(levelname)s: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-    stream=sys.stderr)
-logger = logging.getLogger()
 
 class Command(BaseCommand):
     args = "<keyserver> <keyring_path> [ownertrust_path]"
@@ -30,45 +22,43 @@ class Command(BaseCommand):
         parser.add_argument('args', nargs='*', help='<arch> <filename>')
 
     def handle(self, *args, **options):
-        v = int(options.get('verbosity', None))
-        if v == 0:
-            logger.level = logging.ERROR
-        elif v == 1:
-            logger.level = logging.INFO
-        elif v >= 2:
-            logger.level = logging.DEBUG
-
         if len(args) < 2:
             raise CommandError("keyserver and keyring_path must be provided")
 
-        generate_keyring(args[0], args[1])
+        self.generate_keyring(args[0], args[1])
 
         if len(args) > 2:
-            generate_ownertrust(args[2])
+            self.generate_ownertrust(args[2])
 
+    def generate_keyring(self, keyserver, keyring):
+        self.logger.info("getting all known key IDs")
 
-def generate_keyring(keyserver, keyring):
-    logger.info("getting all known key IDs")
+        # Screw you Django, for not letting one natively do value != <empty string>
+        key_ids = UserProfile.objects.filter(
+                pgp_key__isnull=False).extra(where=["pgp_key != ''"]).values_list(
+                "pgp_key", flat=True)
+        self.logger.info("%d keys fetched from user profiles", len(key_ids))
+        master_key_ids = MasterKey.objects.values_list("pgp_key", flat=True)
+        self.logger.info("%d keys fetched from master keys", len(master_key_ids))
 
-    # Screw you Django, for not letting one natively do value != <empty string>
-    key_ids = UserProfile.objects.filter(
-            pgp_key__isnull=False).extra(where=["pgp_key != ''"]).values_list(
-            "pgp_key", flat=True)
-    logger.info("%d keys fetched from user profiles", len(key_ids))
-    master_key_ids = MasterKey.objects.values_list("pgp_key", flat=True)
-    logger.info("%d keys fetched from master keys", len(master_key_ids))
+        # GPG is stupid and interprets any filename without path portion as being
+        # in ~/.gnupg/. Fake it out if we just get a bare filename.
+        if '/' not in keyring:
+            keyring = './%s' % keyring
+        gpg_cmd = ["gpg", "--no-default-keyring", "--keyring", keyring,
+                "--keyserver", keyserver, "--recv-keys"]
+        self.logger.info("running command: %r", gpg_cmd)
+        gpg_cmd.extend(key_ids)
+        gpg_cmd.extend(master_key_ids)
+        subprocess.check_call(gpg_cmd)
+        self.logger.info("keyring at %s successfully updated", keyring)
 
-    # GPG is stupid and interprets any filename without path portion as being
-    # in ~/.gnupg/. Fake it out if we just get a bare filename.
-    if '/' not in keyring:
-        keyring = './%s' % keyring
-    gpg_cmd = ["gpg", "--no-default-keyring", "--keyring", keyring,
-            "--keyserver", keyserver, "--recv-keys"]
-    logger.info("running command: %r", gpg_cmd)
-    gpg_cmd.extend(key_ids)
-    gpg_cmd.extend(master_key_ids)
-    subprocess.check_call(gpg_cmd)
-    logger.info("keyring at %s successfully updated", keyring)
+    def generate_ownertrust(self, trust_path):
+        master_key_ids = MasterKey.objects.values_list("pgp_key", flat=True)
+        with open(trust_path, "w") as trustfile:
+            for key_id in master_key_ids:
+                trustfile.write("%s:%d:\n" % (key_id, TRUST_LEVELS['marginal']))
+        self.logger.info("trust file at %s created or overwritten", trust_path)
 
 
 TRUST_LEVELS = {
@@ -80,13 +70,5 @@ TRUST_LEVELS = {
     'fully': 5,
     'ultimate': 6,
 }
-
-
-def generate_ownertrust(trust_path):
-    master_key_ids = MasterKey.objects.values_list("pgp_key", flat=True)
-    with open(trust_path, "w") as trustfile:
-        for key_id in master_key_ids:
-            trustfile.write("%s:%d:\n" % (key_id, TRUST_LEVELS['marginal']))
-    logger.info("trust file at %s created or overwritten", trust_path)
 
 # vim: set ts=4 sw=4 et:

--- a/devel/management/commands/rematch_developers.py
+++ b/devel/management/commands/rematch_developers.py
@@ -11,88 +11,70 @@ matching up to a developer if we can find one.
 Usage: ./manage.py rematch_developers
 """
 
-from django.core.management.base import BaseCommand
 from django.db import transaction
 
-import sys
-import logging
-
+from main.management.command import BaseCommand
 from devel.utils import UserFinder
 from main.models import Package
 from packages.models import FlagRequest
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s -> %(levelname)s: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-    stream=sys.stderr)
-logger = logging.getLogger()
 
 class Command(BaseCommand):
     help = "Match and map objects in database to developer emails"
 
     def handle(self, **options):
-        v = int(options.get('verbosity', None))
-        if v == 0:
-            logger.level = logging.ERROR
-        elif v == 1:
-            logger.level = logging.INFO
-        elif v >= 2:
-            logger.level = logging.DEBUG
-
         finder = UserFinder()
-        match_packager(finder)
-        match_flagrequest(finder)
+        self.match_packager(finder)
+        self.match_flagrequest(finder)
 
-@transaction.atomic
-def match_packager(finder):
-    logger.info("getting all unmatched packager strings")
-    package_count = matched_count = 0
-    mapping = {}
+    @transaction.atomic
+    def match_packager(self, finder):
+        self.logger.info("getting all unmatched packager strings")
+        package_count = matched_count = 0
+        mapping = {}
 
-    unmatched = Package.objects.filter(packager__isnull=True).values_list(
-            'packager_str', flat=True).order_by().distinct()
+        unmatched = Package.objects.filter(packager__isnull=True).values_list(
+                'packager_str', flat=True).order_by().distinct()
 
-    logger.info("%d packager strings retrieved", len(unmatched))
-    for packager in unmatched:
-        logger.debug("packager string %s", packager)
-        user = finder.find(packager)
-        if user:
-            mapping[packager] = user
-            logger.debug("  found user %s", user.username)
-            matched_count += 1
+        self.logger.info("%d packager strings retrieved", len(unmatched))
+        for packager in unmatched:
+            self.logger.debug("packager string %s", packager)
+            user = finder.find(packager)
+            if user:
+                mapping[packager] = user
+                self.logger.debug("  found user %s", user.username)
+                matched_count += 1
 
-    for packager_str, user in mapping.items():
-        package_count += Package.objects.filter(packager__isnull=True,
-                packager_str=packager_str).update(packager=user)
+        for packager_str, user in mapping.items():
+            package_count += Package.objects.filter(packager__isnull=True,
+                    packager_str=packager_str).update(packager=user)
 
-    logger.info("%d packages updated, %d packager strings matched",
-            package_count, matched_count)
+        self.logger.info("%d packages updated, %d packager strings matched",
+                package_count, matched_count)
 
 
-@transaction.atomic
-def match_flagrequest(finder):
-    logger.info("getting all flag request email addresses from unknown users")
-    req_count = matched_count = 0
-    mapping = {}
+    @transaction.atomic
+    def match_flagrequest(self, finder):
+        self.logger.info("getting all flag request email addresses from unknown users")
+        req_count = matched_count = 0
+        mapping = {}
 
-    unmatched = FlagRequest.objects.filter(user__isnull=True).values_list(
-            'user_email', flat=True).order_by().distinct()
+        unmatched = FlagRequest.objects.filter(user__isnull=True).values_list(
+                'user_email', flat=True).order_by().distinct()
 
-    logger.info("%d email addresses retrieved", len(unmatched))
-    for user_email in unmatched:
-        logger.debug("email %s", user_email)
-        user = finder.find_by_email(user_email)
-        if user:
-            mapping[user_email] = user
-            logger.debug("  found user %s", user.username)
-            matched_count += 1
+        self.logger.info("%d email addresses retrieved", len(unmatched))
+        for user_email in unmatched:
+            self.logger.debug("email %s", user_email)
+            user = finder.find_by_email(user_email)
+            if user:
+                mapping[user_email] = user
+                self.logger.debug("  found user %s", user.username)
+                matched_count += 1
 
-    for user_email, user in mapping.items():
-        req_count += FlagRequest.objects.filter(user__isnull=True,
-                user_email=user_email).update(user=user)
+        for user_email, user in mapping.items():
+            req_count += FlagRequest.objects.filter(user__isnull=True,
+                    user_email=user_email).update(user=user)
 
-    logger.info("%d request emails updated, %d emails matched",
-            req_count, matched_count)
+        self.logger.info("%d request emails updated, %d emails matched",
+                req_count, matched_count)
 
 # vim: set ts=4 sw=4 et:

--- a/devel/tests/test_pgp_import.py
+++ b/devel/tests/test_pgp_import.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -30,8 +30,10 @@ class PGPImportTest(TransactionTestCase):
     @patch('devel.management.commands.pgp_import.call_gpg')
     def test_pgp_import_garbage_data(self, mock_call_gpg):
         mock_call_gpg.return_value = 'barf'
-        with patch('devel.management.commands.pgp_import.logger') as logger:
-            call_command('pgp_import', '/tmp')
+
+        logger = Mock()
+        call_command('pgp_import', '/tmp', logger=logger)
+
         logger.info.assert_called()
         logger.info.assert_any_call('created %d, updated %d signatures', 0, 0)
         logger.info.assert_any_call('created %d, updated %d keys', 0, 0)
@@ -39,8 +41,10 @@ class PGPImportTest(TransactionTestCase):
     @patch('devel.management.commands.pgp_import.call_gpg')
     def test_pgp_import(self, mock_call_gpg):
         mock_call_gpg.return_value = '\n'.join(SIG_DATA)
-        with patch('devel.management.commands.pgp_import.logger') as logger:
-            call_command('pgp_import', '/tmp')
+
+        logger = Mock()
+        call_command('pgp_import', '/tmp', logger=logger)
+
         logger.info.assert_called()
         logger.info.assert_any_call('created %d, updated %d signatures', 0, 0)
         logger.info.assert_any_call('created %d, updated %d keys', 1, 0)

--- a/devel/tests/test_rematch_developers.py
+++ b/devel/tests/test_rematch_developers.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock
 
 
 from django.core.management import call_command
@@ -9,6 +9,6 @@ class RematchDeveloperTest(TransactionTestCase):
     fixtures = ['main/fixtures/arches.json', 'main/fixtures/repos.json']
 
     def test_rematch_developers(self):
-        with patch('devel.management.commands.rematch_developers.logger') as logger:
-            call_command('rematch_developers')
+        logger = Mock()
+        call_command('rematch_developers', logger=logger)
         logger.info.assert_called()

--- a/main/log.py
+++ b/main/log.py
@@ -1,4 +1,7 @@
 # Derived from Django snippets: http://djangosnippets.org/snippets/2242/
+
+import logging
+
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from hashlib import md5
@@ -66,5 +69,10 @@ class RateLimitFilter(object):
             self.errors[key] = now
 
         return not duplicate
+
+
+class StdOutFilter(logging.Filter):
+    def filter(self, record):
+        return record.levelno < logging.WARNING
 
 # vim: set ts=4 sw=4 et:

--- a/main/management/command.py
+++ b/main/management/command.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.core import management
+
+
+class BaseCommand(management.base.BaseCommand):
+    stealth_options = ('logger',)
+    __verbosity_to_level = [ logging.WARNING, logging.INFO, logging.DEBUG ]
+
+    def __init__(self, *args, **kwargs):
+        super(BaseCommand, self).__init__(*args, **kwargs)
+        self.logger = logging.getLogger('archweb.command')
+
+    def execute(self, *args, **options):
+        verbosity = int(options.get('verbosity', 1))
+        level = self.__verbosity_to_loglevel(verbosity)
+        self.logger.setLevel(level)
+
+        if options.get('logger'):
+            self.logger = options['logger']
+
+        super(BaseCommand, self).execute(*args, **options)
+
+    @classmethod
+    def __verbosity_to_loglevel(cls, verbosity):
+        if verbosity < 0:
+            return logging.WARNING
+        if verbosity >= len(cls.__verbosity_to_level):
+            return logging.DEBUG
+        return cls.__verbosity_to_level[verbosity]

--- a/settings.py
+++ b/settings.py
@@ -130,24 +130,52 @@ INSTALLED_APPS = (
 # Logging configuration for not getting overspammed
 LOGGING = {
     'version': 1,
+    'formatters': {
+        'verbose': {
+            'format': '{asctime} -> {levelname}: {message}',
+            'datefmt': '%Y-%m-%d %H:%M:%S',
+            'style': '{',
+        },
+    },
     'filters': {
         'ratelimit': {
             '()': 'main.log.RateLimitFilter',
-        }
+        },
+        'stdout': {
+            '()': 'main.log.StdOutFilter',
+        },
     },
     'handlers': {
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['ratelimit'],
             'class': 'django.utils.log.AdminEmailHandler',
-        }
+        },
+        'stdout': {
+            'level': 'INFO',
+            'filters': ['stdout'],
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
+            'formatter': 'verbose'
+        },
+        'stderr': {
+            'level': 'WARNING',
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stderr',
+            'formatter': 'verbose'
+        },
     },
     'loggers': {
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,
-        }
+        },
+        'archweb.command': {
+            'handlers': ['stdout', 'stderr'],
+            'level': 'INFO',
+            'propagate': False,
+        },
     },
 }
 


### PR DESCRIPTION
Django does not currently have logging functionalities for commands:
https://code.djangoproject.com/ticket/21429

This PR introduces a preconfigured logger instance in `main.management.command.BaseCommand` that can be used for command logging.

The `--verbosity` option is taken into account:
  - 0: ERROR..WARNING
  - 1: ERROR..INFO
  - 2: ERROR..DEBUG
  - 3: unused

The logger instance is configurable, its name is `archweb.command`.
Errors and warnings are forwarded to stderr, everything else appears on stdout.

Colors are currently not supported.

Resolves #209