### PR TITLE
main: Handle multiple testing repositories

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -397,8 +397,9 @@ class Package(models.Model):
         if self.repo.testing:
             return None
         try:
-            return Package.objects.normal().get(repo__testing=True,
-                    pkgname=self.pkgname, arch=self.arch)
+            # Kde-unstable is also a [testing] repo so sort on id.
+            return Package.objects.filter(repo__testing=True,
+                    pkgname=self.pkgname, arch=self.arch).order_by('-id').first()
         except Package.DoesNotExist:
             return None
 


### PR DESCRIPTION
Since there are multiple [testing] repositories when a package is in
kde-unstable, testing and flagged in extra the in_testing function will
generate an error since there are multiple results. Rewrite the query so
it handles multiple results and order it by id since [testing] should
have a lower id then kde-unstable.