### PR TITLE
add security information page

### DIFF
--- a/public/views.py
+++ b/public/views.py
@@ -168,4 +168,20 @@ def keys_json(request):
     to_json = json.dumps(data, ensure_ascii=False)
     return HttpResponse(to_json, content_type='application/json')
 
+@cache_control(max_age=307)
+def security(request):
+
+    # FIXME: we may want to sort by firstname,lastname
+    developer_keys = DeveloperKey.objects.select_related(
+            'owner').filter(owner__isnull=False)
+
+    # FIXME this is probably not the way we want to do things for now.
+    SECURITY_TEAM = {'anthraxx', 'rgacogne', 'shibumi', 'jelle', 'sangy', 'Foxboron'}
+    developer_keys = [key for key in developer_keys if key.owner.userprofile.alias in SECURITY_TEAM]
+    context = {
+        'keys': developer_keys,
+    }
+    return render(request, 'public/security.html', context)
+
+
 # vim: set ts=4 sw=4 et:

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
                 <li id="anb-forums"><a href="https://bbs.archlinux.org/" title="Community forums">Forums</a></li>
                 <li id="anb-wiki"><a href="https://wiki.archlinux.org/" title="Community documentation">Wiki</a></li>
                 <li id="anb-bugs"><a href="https://bugs.archlinux.org/" title="Report and track bugs">Bugs</a></li>
-                <li id="anb-security"><a href="https://security.archlinux.org/" title="Arch Linux Security Tracker">Security</a></li>
+                <li id="anb-security"><a href="/security/" title="Arch Linux Security">Security</a></li>
                 <li id="anb-aur"><a href="https://aur.archlinux.org/" title="Arch Linux User Repository">AUR</a></li>
                 <li id="anb-download"><a href="{% url 'page-download' as pdl %}{{ pdl }}" title="Get Arch Linux">Download</a></li>
             </ul>

--- a/templates/public/security.html
+++ b/templates/public/security.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Arch Linux - Security{% endblock %}
+{% block content %}
+{% load pgp %}
+
+<div class="box">
+    <h2 class="title">Arch Linux Security</h2>
+
+    For Arch Linux security is paramount, and a dedicated team of staffers and
+    volunteers helps with triaging, prioritizing, confirming, patching and
+    notifying about vulnerabilities in Arch Linux components as well as
+    packages provided in the official repositories.
+
+    <h3> Reporting Vulnerablities in Arch Linux Components or Infrastructure</h3>
+
+    If you have discovered a vulnerability in packages related to core
+    components or in Arch Linux infrastructure don't hesitate to reach out 
+    to <a href="mailto:security@archlinux.org">security@archlinux.org</a> to
+    discuss remediation. You can encrypt your email to the following gpg keys.
+
+
+    <ul>
+    {% for key in keys %}
+       {% with key.owner.userprofile as owner_profile %}
+       {{ key.owner.name }}
+       <li><a href="{{ owner_profile.get_absolute_url }}">{{ key.owner.get_full_name }}</a>
+       <tt>{{ key.pgp_key|pgp_fingerprint }}</tt>
+       {% pgp_key_link owner_profile.pgp_key %}
+       {% endwith %}
+	{% endfor %}
+    </ul>
+
+    <h3>Vulnerabilities in Upstream Packages</h3>
+
+    Our <a href="https://security.archlinux.org">CVE tracker</a> can help you
+    review the vulnerabilities that affect the packages we provide. If you
+    think a CVE that affects a package is not listed in there, do not hesitate
+    to reach out to us in irc on <tt>#archlinux-security</tt>.
+
+    <h3>Securing your Arch Linux installation</h3>
+
+    Consider checking this 
+    <a href="https://wiki.archlinux.org/security/">Wiki page for more information</a>
+
+{% endblock %}
+

--- a/urls.py
+++ b/urls.py
@@ -48,6 +48,7 @@ urlpatterns.extend([
     url(r'^master-keys/$', public.views.keys, name='page-keys'),
     url(r'^master-keys/json/$', public.views.keys_json, name='pgp-keys-json'),
     url(r'^people/(?P<slug>[-\w]+)/$', public.views.people, name='people'),
+    url(r'^security/$', public.views.security, name='security'),
 ])
 
 # Feeds patterns, used below


### PR DESCRIPTION
After discussion with some of the security team, we decided that having more upfront information about disclosing vulnerability information with the security team would be useful.

This relates to [this issue](https://kanboard.archlinux.org/project/8/task/176) in the kanboard.

cc @Foxboron @jelly 