### PR TITLE
todolist: send email when the todolist is fully complete

### DIFF
--- a/templates/todolists/complete_email_notification.txt
+++ b/templates/todolists/complete_email_notification.txt
@@ -1,0 +1,8 @@
+{% autoescape off %}The todo list "{{ todolist.name }}" is complete.
+
+Todo list information:
+Name: {{ todolist.name }}
+URL: {{ todolist.get_full_url }}
+Creator: {{ todolist.creator.get_full_name }}
+Description:
+{{ todolist.description|striptags|wordwrap:78 }}{% endautoescape %}


### PR DESCRIPTION
When a todolist item is complete ie. all TodoListPackages belonging to
the todolist are marked as COMPLETE inform the creator of the todolist
via an email.

Closes: #222

Signed-off-by: Jelle van der Waa <jelle@vdwaa.nl>