### PR TITLE
Developing locally needs CSRF_COOKIE_SECURE=False

### DIFF
--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -39,10 +39,11 @@ CACHES = {
     }
 }
 
-## Use secure session cookies? Make this true if you want all
+## Use secure session cookies? Make these True if you want all
 ## logged-in actions to take place over HTTPS only. If developing
 ## locally, you will want to use False.
 SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
 
 ## location for saving dev pictures
 MEDIA_ROOT = '/srv/example.com/img/'


### PR DESCRIPTION
When I started developing archweb locally today, I couldn't log in due to missing CSRF cookie. It turns out that `settings.CSRF_COOKIE_SECURE` (which works like `SESSION_COOKIE_SECURE`) needs to be `False` when accessing the site via plaintext HTTP.

Hope this patch could get future contributors started a little easier.