### PR TITLE
Add django-extensions to the default installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,12 @@ IPy==1.00
 Markdown==3.1.1
 bencode.py==2.0.0
 django-countries==5.5
+django-extensions==2.2.1
 jsmin==2.2.2
 pgpdump==1.5
-pytz>=2017.3
+pytz>=2019.2
 parse==1.12.1
 django-jinja==2.4.1
 sqlparse==0.3.0
 django-csp==3.5
+ptpython==2.0.4

--- a/settings.py
+++ b/settings.py
@@ -115,6 +115,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.staticfiles',
     'django_countries',
+    'django_extensions',
 
     'main',
     'mirrors',


### PR DESCRIPTION
Django extensions comes with a lot of goodies, including shell_plus. As a default,
included ptpython for default shell, but this can be overridden by installing another
shell (bpython, ipython) and setting the SHELL_PLUS variable on local_settings.py.