### PR TITLE
Add information about official docker image

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -81,8 +81,8 @@
 
     <h3>Docker image</h3>
 
-    <p>A Docker image is available on <a href="https://hub.docker.com/r/archlinux/base/">Docker Hub</a>. You can run the image with the following command:</p>
-    <code>docker run -it archlinux/base</code>
+    <p>The official Docker image is available on <a href="https://hub.docker.com/_/archlinux/">Docker Hub</a>. You can run the image with the following command:</p>
+    <code>docker run -it archlinux</code>
 
     <h3>HTTP Direct Downloads</h3>
 


### PR DESCRIPTION
We have an official docker image now, let's mention that on our
`Download` page.

Signed-off-by: Christian Rebischke <chris@nullday.de>