### PR TITLE
news: Add the MAILMAN_PASSWORD option and use it for sending authenticated emails

### DIFF
--- a/news/views.py
+++ b/news/views.py
@@ -1,5 +1,6 @@
 from django import forms
-from django.core.mail import send_mail
+from django.conf import settings
+from django.core.mail import EmailMessage
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template import loader
@@ -39,16 +40,19 @@ class NewsCreateView(CreateView):
         newsitem.author = self.request.user
         newsitem.slug = find_unique_slug(News, newsitem.title)
         newsitem.save()
-        if newsitem.send_announce:
+        if newsitem.send_announce and settings.MAILMAN_PASSWORD:
             ctx = {
                 'news': newsitem,
             }
+            headers = {
+                'Approved': settings.MAILMAN_PASSWORD,
+            }
             template = loader.get_template('news/news_email_notification.txt')
-            send_mail('[arch-announce] %s' % newsitem.title,
-                      template.render(ctx),
-                      '"Arch Linux: Recent news updates: %s" <arch-announce@archlinux.org>' % newsitem.author.get_full_name(),
-                      ['arch-announce@archlinux.org'],
-                      fail_silently=True)
+            EmailMessage(subject='[arch-announce] %s' % newsitem.title,
+                      body=template.render(ctx),
+                      from_email='"Arch Linux: Recent news updates: %s" <arch-announce@archlinux.org>' % newsitem.author.get_full_name(),
+                      to=['arch-announce@archlinux.org'],
+                      headers=headers).send()
         return super(NewsCreateView, self).form_valid(form)
 
 

--- a/news/views.py
+++ b/news/views.py
@@ -40,13 +40,13 @@ class NewsCreateView(CreateView):
         newsitem.author = self.request.user
         newsitem.slug = find_unique_slug(News, newsitem.title)
         newsitem.save()
-        if newsitem.send_announce and settings.MAILMAN_PASSWORD:
+        if newsitem.send_announce:
             ctx = {
                 'news': newsitem,
             }
-            headers = {
-                'Approved': settings.MAILMAN_PASSWORD,
-            }
+            headers = dict()
+            if settings.MAILMAN_PASSWORD:
+                headers['Approved'] = settings.MAILMAN_PASSWORD
             template = loader.get_template('news/news_email_notification.txt')
             EmailMessage(subject='[arch-announce] %s' % newsitem.title,
                       body=template.render(ctx),

--- a/settings.py
+++ b/settings.py
@@ -178,6 +178,9 @@ COUNTRIES_OVERRIDE = {
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '00000000000000000000000000000000000000000000000'
 
+# Mailman poster password for announcements
+MAILMAN_PASSWORD = ''
+
 DATABASES = {
     'default': {
         'ENGINE':  'django.db.backends.sqlite3',


### PR DESCRIPTION
Given that the whitelisting of the arch-announce email is not sufficient for validation, we are setting a poster password to make sure the list cannot be abused. 