### PR TITLE
Add Packages RSS feeds for "All Stable Repos" and "All Testing Repos"

### DIFF
--- a/templates/public/feeds.html
+++ b/templates/public/feeds.html
@@ -44,6 +44,20 @@
                 <td><a href="/feeds/packages/{{ arch }}/" class="rss">Feed</a></td>
                 {% endfor %}
             </tr>
+            <tr>
+                <td><strong>All Stable Repos</strong></td>
+                <td><a href="/feeds/packages/all/stable-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/{{ arch }}/stable-repos/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            <tr>
+                <td><strong>All Testing Repos</strong></td>
+                <td><a href="/feeds/packages/all/testing-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/{{ arch }}/testing-repos/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
             {% for repo in repos %}
             <tr>
                 <td><strong>{{ repo }}</strong></td>
@@ -78,6 +92,20 @@
                 <td><a href="/feeds/packages/added/{{ arch }}/" class="rss">Feed</a></td>
                 {% endfor %}
             </tr>
+            <tr>
+                <td><strong>All Stable Repos</strong></td>
+                <td><a href="/feeds/packages/added/all/stable-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/added/{{ arch }}/stable-repos/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            <tr>
+                <td><strong>All Testing Repos</strong></td>
+                <td><a href="/feeds/packages/added/all/testing-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/added/{{ arch }}/testing-repos/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
             {% for repo in repos %}
             <tr>
                 <td><strong>{{ repo }}</strong></td>
@@ -107,6 +135,20 @@
                 <td><a href="/feeds/packages/removed/" class="rss">Feed</a></td>
                 {% for arch in arches %}
                 <td><a href="/feeds/packages/removed/{{ arch }}/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            <tr>
+                <td><strong>All Stable Repos</strong></td>
+                <td><a href="/feeds/packages/removed/all/stable-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/removed/{{ arch }}/stable-repos/" class="rss">Feed</a></td>
+                {% endfor %}
+            </tr>
+            <tr>
+                <td><strong>All Testing Repos</strong></td>
+                <td><a href="/feeds/packages/removed/all/testing-repos/" class="rss">Feed</a></td>
+                {% for arch in arches %}
+                <td><a href="/feeds/packages/removed/{{ arch }}/testing-repos/" class="rss">Feed</a></td>
                 {% endfor %}
             </tr>
             {% for repo in repos %}


### PR DESCRIPTION
Hello,
on the bug tracker there is [FS#59329](https://bugs.archlinux.org/task/59329) task named `Added/removed packages feed for "all repos" should only include main repos`.

I added two new RSS feed groups for the packages updates and additions/removals.

One is for the stable packages from the  official repositories
and one is for the testing packages from the official repositories.
The corresponding links are generated on the /feeds/ page.