### PR TITLE
netboot: add downgraded cipher banner

### DIFF
--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -54,4 +54,7 @@ MEDIA_URL = '/media/img/'
 ## Make this unique, and don't share it with anybody.
 SECRET_KEY = '00000000000000000000000000000000000000000000000'
 
+## Display a warning if serving netboot images on downgraded ciphers
+NETBOOT_SECURITY_BANNER=True
+
 # vim: set ts=4 sw=4 et:

--- a/releng/views.py
+++ b/releng/views.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.generic import DetailView, ListView
+from django.conf import settings
 
 from .models import Release
 from mirrors.models import MirrorUrl
@@ -89,6 +90,7 @@ def netboot_config(request):
     return render(request, "releng/archlinux.ipxe", context, content_type='text/plain')
 
 def netboot_info(request):
-    return render(request, "releng/netboot.html", None)
+    return render(request, "releng/netboot.html", 
+            {'security_banner':  settings.NETBOOT_SECURITY_BANNER})
 
 # vim: set ts=4 sw=4 et:

--- a/settings.py
+++ b/settings.py
@@ -228,4 +228,7 @@ if DEBUG_TOOLBAR:
 
     INSTALLED_APPS = list(INSTALLED_APPS) + ['debug_toolbar']
 
+## Display a warning if serving netboot images on downgraded ciphers
+NETBOOT_SECURITY_BANNER=True
+
 # vim: set ts=4 sw=4 et:

--- a/templates/releng/netboot.html
+++ b/templates/releng/netboot.html
@@ -28,6 +28,19 @@ The integrity of all downloaded files is verified with cryptographic signatures.
 
 </p>
 
+{% if security_banner  %}
+<h3> A note on security </h3>
+
+Be advised that, due to limitations with the <a
+    href='https://lists.ipxe.org/pipermail/ipxe-devel/2019-November/006808.html'>iPXE
+    SSL stack</a>, the chainloading script for the iPXE image is served using a
+downgraded list of cipher-suites under ipxe.archlinux.org. The cipher-suites
+---RSA-AES256-CBC-SHA256 -- served on this domain are not the recommended list
+on the mozilla observatory, yet they still yield a reasonable degree of
+protection/authentication.
+
+{% endif %}
+
 <h3>Download</h3>
 
 <h4>BIOS</h4>


### PR DESCRIPTION
The banner is pretty self-explanatory. Inform users that the chainloaded
script is served on downgraded ciphers due to a limitation on the ssl
stack of ipxe. Also, add a configuration variable so that downstream
users of archweb can prevent the banner from displaying.