### PR TITLE
allow todo list name to wrap

### DIFF
--- a/templates/devel/index.html
+++ b/templates/devel/index.html
@@ -136,7 +136,7 @@
         <tbody>
             {% for todo in todos %}
             <tr>
-                <td><a href="{{ todo.get_absolute_url }}"
+                <td class="wrap"><a href="{{ todo.get_absolute_url }}"
                         title="View todo list: {{ todo.name }}">{{ todo.name }}</a></td>
                 <td>{{ todo.created|date }}</td>
                 <td>{{ todo.creator.get_full_name }}</td>

--- a/templates/todolists/list.html
+++ b/templates/todolists/list.html
@@ -35,7 +35,7 @@
         <tbody>
             {% for list in lists %}
             <tr>
-                <td><a href="{{ list.get_absolute_url }}"
+                <td class="wrap"><a href="{{ list.get_absolute_url }}"
                         title="View todo list: {{ list.name }}">{{ list.name }}</a></td>
                 <td>{{ list.created|date }}</td>
                 <td>{{ list.creator.get_full_name }}</td>


### PR DESCRIPTION
We have quite long todo list names, with attribute "nowrap" this looks
pretty strange on small screens.