### PR TITLE
Include package branch in svntogit links

### DIFF
--- a/main/templatetags/details_link.py
+++ b/main/templatetags/details_link.py
@@ -21,7 +21,7 @@ def details_link(pkg):
 @register.simple_tag
 def scm_link(package, operation):
     parts = (package.repo.svn_root, operation, package.pkgbase)
-    linkbase = ("https://github.com/archlinux/svntogit-%s/%s/master/%s/trunk")
+    linkbase = ("https://github.com/archlinux/svntogit-%s/%s/packages/%s/trunk")
     return linkbase % tuple(urlquote(part.encode('utf-8')) for part in parts)
 
 


### PR DESCRIPTION
Git log operations on the master branch take too long to finish and the
history pages on GitHub time out because of this. Switch to using the
package branches similar to how it was done when svntogit was on cgit.

Fixes: https://github.com/archlinux/archweb/issues/290