### PR TITLE
Fix PXE netboot image names

### DIFF
--- a/templates/releng/archlinux.ipxe
+++ b/templates/releng/archlinux.ipxe
@@ -124,13 +124,15 @@ goto main
 :boot
 echo Booting Arch Linux x86_64 ${release} from ${mirrorurl}
 echo
-kernel ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz || goto failed_download
-imgverify vmlinuz ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz.ipxe.sig || goto failed_verify
-initrd ${mirrorurl}iso/${release}/arch/boot/intel_ucode.img || goto failed_download
-imgverify intel_ucode.img ${mirrorurl}iso/${release}/arch/boot/intel_ucode.img.ipxe.sig || goto failed_verify
+kernel ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz-linux || goto failed_download
+imgverify vmlinuz-linux ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz-linux.ipxe.sig || goto failed_verify
+initrd ${mirrorurl}iso/${release}/arch/boot/amd-ucode.img || goto failed_download
+imgverify intel_ucode.img ${mirrorurl}iso/${release}/arch/boot/amd-ucode.img.ipxe.sig || goto failed_verify
+initrd ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img || goto failed_download
+imgverify intel_ucode.img ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/x86_64/archiso.img || goto failed_download
 imgverify archiso.img ${mirrorurl}iso/${release}/arch/boot/x86_64/archiso.img.ipxe.sig || goto failed_verify
-imgargs vmlinuz initrd=intel_ucode.img initrd=archiso.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y ${extrabootoptions}
+imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=archiso.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y ${extrabootoptions}
 boot || goto failed_boot
 
 :failed_download


### PR DESCRIPTION
templates/releng/archlinux.ipxe:
Fix the naming of the initrd images.
In a commit leading to archiso 46 [1] (image 2020-08-01) the way files
are being copied in the build script has been made more generic. Due to
this change the names of the provided PXE netboot images on the download
servers have changed as well and stopped matching the files as provided
in archweb's .ipxe template.
Add amd-ucode.img as additional initird to be downloaded, verified and
used.

[1] https://gitlab.archlinux.org/archlinux/archiso/-/commit/47e11125e4672fc3448caefa6728439160daedd3