### PR TITLE
Fix PXE netboot image names (for real)

### DIFF
--- a/templates/releng/archlinux.ipxe
+++ b/templates/releng/archlinux.ipxe
@@ -127,9 +127,9 @@ echo
 kernel ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz-linux || goto failed_download
 imgverify vmlinuz-linux ${mirrorurl}iso/${release}/arch/boot/x86_64/vmlinuz-linux.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/amd-ucode.img || goto failed_download
-imgverify intel_ucode.img ${mirrorurl}iso/${release}/arch/boot/amd-ucode.img.ipxe.sig || goto failed_verify
+imgverify amd-ucode.img ${mirrorurl}iso/${release}/arch/boot/amd-ucode.img.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img || goto failed_download
-imgverify intel_ucode.img ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img.ipxe.sig || goto failed_verify
+imgverify intel-ucode.img ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/x86_64/archiso.img || goto failed_download
 imgverify archiso.img ${mirrorurl}iso/${release}/arch/boot/x86_64/archiso.img.ipxe.sig || goto failed_verify
 imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=archiso.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y ${extrabootoptions}


### PR DESCRIPTION
templates/releng/archlinux.ipxe:
It seems that two copy/paste errors were introduced in the last pull
request [1] evolving around the renaming of initrd image names, which is
relevant for PXE netboot as well.

[1] https://github.com/archlinux/archweb/pull/294