### PR TITLE
Fix rendering of headings inside news previews

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -494,6 +494,24 @@ h3 span.arrow {
     line-height: 0px;
 }
 
+/* home: headings inside news previews */
+#news div.article-content h1,
+#news div.article-content h2,
+#news div.article-content h3,
+#news div.article-content h4,
+#news div.article-content h5 {
+    /* cancel styling for #news h3 */
+    float: none;
+    padding-bottom: 0em;
+    /* cancel styling for #news h4 */
+    clear: none;
+    border-bottom: none;
+    /* force the style of normal h5 */
+    font-size: 1em;
+    margin-top: 1em;
+    margin-bottom: 0em;
+}
+
 /* planet: posts */
 #planet {
     margin-top: 1.5em;


### PR DESCRIPTION
The latest news entry ([Kill Arch Bugs: Help us on the 13th of September!](https://www.archlinux.org/news/kill-arch-bugs-help-us-on-the-13th-of-september/)) contains `h3` headings, which are rendered incorrectly on the main archlinux.org page - they are left-floated and too big and outside of the hierarchy (the "Latest News" is `h3` and the titles of the news are `h4`, so headings inside the news should be `h5` or `h6`). This commit fixes the visual problem by styling all headings inside the news previews to look the same as `h5`.