### PR TITLE
Add core.db.tar.zst support for reporead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ ptpython==2.0.4
 feedparser==6.0.1
 bleach==3.2.0
 requests==2.24.0
+xtarfile==0.0.4
+zstandard==0.14.0


### PR DESCRIPTION
As Python does not support zstd compression yet, xtarfile a wrapper
around tarfile with zstd support is required.