### PR TITLE
Add complete status to the todolist json endpoint

### DIFF
--- a/packages/utils.py
+++ b/packages/utils.py
@@ -15,6 +15,7 @@ from main.utils import (database_vendor,
 from .models import (PackageGroup, PackageRelation,
         License, Depend, Conflict, Provision, Replacement,
         SignoffSpecification, Signoff, fake_signoff_spec)
+from todolists.models import TodolistPackage
 
 
 VERSION_RE = re.compile(r'^((\d+):)?(.+)-([^-]+)$')
@@ -429,6 +430,7 @@ class PackageJSONEncoder(DjangoJSONEncoder):
             'maintainers', 'packager']
     pkg_list_attributes = ['groups', 'licenses', 'conflicts',
             'provides', 'replaces']
+    todolistpackage_attributes = ['status_str']
 
     def default(self, obj):
         if hasattr(obj, '__iter__'):
@@ -453,6 +455,11 @@ class PackageJSONEncoder(DjangoJSONEncoder):
             return str(obj)
         elif isinstance(obj, User):
             return obj.username
+        elif isinstance(obj, TodolistPackage):
+            data = self.default(obj.pkg)
+            for attr in self.todolistpackage_attributes:
+                data[attr] = getattr(obj, attr)
+            return data
         return super(PackageJSONEncoder, self).default(obj)
 
 # vim: set ts=4 sw=4 et:

--- a/todolists/models.py
+++ b/todolists/models.py
@@ -80,6 +80,10 @@ class TodolistPackage(models.Model):
     def status_css_class(self):
         return self.get_status_display().lower().replace('-', '')
 
+    @property
+    def status_str(self):
+        return self.STATUS_CHOICES[self.status][1]
+
 
 def check_todolist_complete(sender, instance, **kwargs):
     if instance.status == instance.INCOMPLETE:

--- a/todolists/views.py
+++ b/todolists/views.py
@@ -241,7 +241,7 @@ class TodoListJSONEncoder(PackageJSONEncoder):
                 'description': obj.description,
                 'created': obj.created,
                 'last_modified': obj.last_modified,
-                'packages': [pkg.pkg for pkg in obj.packages()],
+                'packages': obj.packages()
             }
 
         return super(TodoListJSONEncoder, self).default(obj)


### PR DESCRIPTION
Include the status of a todolist package as a string, so the json output
can be used to determine the completeness or the packages left to
rebuild.