### PR TITLE
Handle 301 when updating planet feeds

### DIFF
--- a/planet/management/commands/update_planet.py
+++ b/planet/management/commands/update_planet.py
@@ -65,6 +65,12 @@ class Command(BaseCommand):
                 cache.set(f'planet:etag:{url}', feed.etag, 86400)
             return
 
+        if http_status == 301:
+            logging.info("The feed '%s' has moved permanently to '%s'", url, feed.href)
+            feed_instance.website_rss = feed.href
+            feed_instance.save()
+            return
+
         if http_status != 200:
             logger.info("error parsing feed: '%s', status: '%s'", url, http_status)
             return

--- a/planet/tests/test_command.py
+++ b/planet/tests/test_command.py
@@ -88,3 +88,12 @@ class UpdatePlanetTest(TestCase):
         parse.return_value = value
         self.command.parse_feed(self.feed)
         assert FeedItem.objects.count() == 1
+
+    @mock.patch('feedparser.parse')
+    def test_parse_feed_301(self, parse):
+        return_value = Result()
+        return_value.status = 301
+        return_value.href = 'https://example.com/rss'
+        parse.return_value = return_value
+        self.command.parse_feed(self.feed)
+        assert self.feed.website_rss == return_value.href


### PR DESCRIPTION
When a 301 is returned the callee is expected to update it's database
entry to reflect this change. As subsequent returning requests to the
old url might lead to ip bans.