### PR TITLE
Install `cssmin` using `poetry` compatible URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+git://github.com/fredj/cssmin.git@master#egg=cssmin
+git+https://github.com/fredj/cssmin.git
 Django==3.1.3
 IPy==1.00
 Markdown==3.2.2


### PR DESCRIPTION
`poetry` doesn't support `requirements.txt` directly, but this works

    cat requirements.txt | xargs poetry add

Maybe consider switching to some more modern supported library.