### PR TITLE
Notify about recently updated packages

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -851,6 +851,12 @@ table.results {
         padding: 0.5em;
     }
 
+    #pkgdetails #pkginfo .recent {
+        color: green;
+        font-weight: bold;
+        text-decoration: underline dotted;
+    }
+
 /* pkgdetails: flag package */
 #flag-pkg-form label {
     width: 10em;

--- a/templates/packages/package_details.html
+++ b/templates/packages/package_details.html
@@ -184,7 +184,7 @@
             <td>Unsigned</td>
         </tr>{% endif %}<tr>
             <th>Last Updated:</th>
-            <td>{{ pkg.last_update|date:"DATETIME_FORMAT" }} UTC</td>
+            <td>{{ pkg.last_update|date:"DATETIME_FORMAT" }} UTC{% if pkg.is_recent %} <span class="recent" title="Your mirror may not yet have this package version">({{ pkg.updated_mins_ago}} minutes ago)</span>{% endif %}</td>
         </tr>
         {% if user.is_authenticated %}{% with flag_request=pkg.flag_request %}{% if flag_request %}<tr>
             <th>Last Flag Request:</th>


### PR DESCRIPTION
This PR adds an extra green text line with "X minutes ago" to recently upgraded packages, next to the update date. This is to notify people that a given version might not yet be synchronized on various mirrors. Looks like this:

![image](https://user-images.githubusercontent.com/1546665/101246839-ffc6ed80-3715-11eb-842c-0ce32e8df5c8.png)
