### PR TITLE
Warn users trying to flag recently updated pkgs

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -871,6 +871,21 @@ table.results {
     display: none;
 }
 
+#flag-pkg-form div.recentwarning {
+    width: calc(45% - 4px); /* Minus padding to match text fields above */
+    padding: 2px 3px;
+    display: inline-block;
+
+    color: white;
+    font-weight: bold;
+    background: #a80000;
+    border: 2px solid black;
+}
+
+#flag-pkg-form div.recentwarning a {
+    color: #c4d3ff;
+}
+
 /* pkgdetails: deps, required by and file lists */
 #pkgdetails #metadata {
     clear: both;

--- a/templates/packages/flag.html
+++ b/templates/packages/flag.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load package_extras %}
+{% load humanize %}
 
 {% block title %}Arch Linux - Flag Package - {{ package.pkgname }} {{ package.full_version }} ({{ package.arch.name }}){% endblock %}
 {% block head %}<meta name="robots" content="noindex"/>{% endblock %}
@@ -38,6 +39,14 @@
         <fieldset>
             {{ form.as_p }}
         </fieldset>
+        {% if package.is_recent %}
+            <div>
+                <label></label>
+                <div class="recentwarning">
+                    This package was updated {{ package.last_update|naturaltime }} and may not yet be available on your mirror. Are you sure {{ package.pkgver }} is not the latest available version{% if package.url %} <a href="{{ package.url }}">from upstream</a>{% endif %}?
+                </div>
+            </div>
+        {% endif %}
         <p><label></label> <input title="Flag {{ package.pkgname }} as out-of-date" type="submit" value="Flag Package" /></p>
     </form>
 </div>


### PR DESCRIPTION
Displays a red bar with a warning message that a given package was updated relatively recently and might not yet be available on all mirrors. It's intentionally designed to look a bit obnoxious so that people hopefully read the message before flagging.

Looks like so (message in the bar now displays the pkgver, ex. 5.8.0, not the full_version, ex. 5.8.0-2):

![image](https://user-images.githubusercontent.com/1546665/103387828-2bb37400-4b06-11eb-965e-1add370c900a.png)
