### PR TITLE
Ignore case on packages exact match search

### DIFF
--- a/packages/views/search.py
+++ b/packages/views/search.py
@@ -59,7 +59,7 @@ class PackageSearchForm(forms.Form):
             return []
         if 'q' not in self.cleaned_data:
             return []
-        return Package.objects.normal().filter(pkgname=self.cleaned_data['q'].lower())
+        return Package.objects.normal().filter(pkgname__iexact=self.cleaned_data['q'])
 
 
 def parse_form(form, packages):

--- a/packages/views/search.py
+++ b/packages/views/search.py
@@ -59,7 +59,7 @@ class PackageSearchForm(forms.Form):
             return []
         if 'q' not in self.cleaned_data:
             return []
-        return Package.objects.normal().filter(pkgname=self.cleaned_data['q'])
+        return Package.objects.normal().filter(pkgname=self.cleaned_data['q'].lower())
 
 
 def parse_form(form, packages):


### PR DESCRIPTION
As described in: https://wiki.archlinux.org/index.php/PKGBUILD#pkgname

"Package names should only consist of lowercase alphanumerics"

Since all packages will have a lowercase name, it seems logical to ignore case when searching.

![2021-01-10_224423](https://user-images.githubusercontent.com/27740271/104141461-b6f9f880-5395-11eb-8932-08621aa24ad6.png)