### PR TITLE
Link man.archlinux.org on the front page

### DIFF
--- a/templates/public/index.html
+++ b/templates/public/index.html
@@ -112,6 +112,8 @@
     <ul>
         <li><a href="https://wiki.archlinux.org/"
             title="Community documentation">Wiki</a></li>
+        <li><a href="https://man.archlinux.org/"
+            title="All manpages from Arch packages">Manual Pages</a></li>
         <li><a href="https://wiki.archlinux.org/index.php/Installation_guide"
             title="Installation guide">Installation Guide</a></li>
     </ul>


### PR DESCRIPTION
Add a link to the sidebar on the front page. (This could also be linked in the global navbar, IMO.)