### PR TITLE
Update wiki links to the new short URL

### DIFF
--- a/main/templatetags/details_link.py
+++ b/main/templatetags/details_link.py
@@ -48,7 +48,7 @@ def bug_report(package):
 
 @register.simple_tag
 def wiki_link(package):
-    url = "https://wiki.archlinux.org/index.php/Special:Search"
+    url = "https://wiki.archlinux.org/title/Special:Search"
     data = {
         'search': package.pkgname,
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
             {% if user.is_authenticated %}
                 <ul>
                     <li><a href="{% url 'devel-index' %}" title="Developer Dashboard">Dashboard</a></li>
-                    <li><a href="https://wiki.archlinux.org/index.php/DeveloperWiki"
+                    <li><a href="https://wiki.archlinux.org/title/DeveloperWiki"
                         title="Developer Wiki">DevWiki</a></li>
                     <li><a href="{% url 'news-list' as newsl %}{{ newsl }}" title="Manage news articles">News</a></li>
                     <li><a href="/packages/signoffs/" title="Package signoffs">Signoffs</a></li>
@@ -79,7 +79,7 @@
                 <a href="mailto:anthraxx@archlinux.org" title="Contact Levente Polyák">Levente Polyák</a>.</p>
 
             <p>The Arch Linux name and logo are recognized
-            <a href="https://wiki.archlinux.org/index.php/DeveloperWiki:TrademarkPolicy"
+            <a href="https://wiki.archlinux.org/title/DeveloperWiki:TrademarkPolicy"
                 title="Arch Linux Trademark Policy">trademarks</a>. Some rights reserved.</p>
 
             <p>The registered trademark Linux® is used pursuant to a sublicense from LMI,

--- a/templates/mirrors/mirrorlist_generate.html
+++ b/templates/mirrors/mirrorlist_generate.html
@@ -28,7 +28,7 @@
     <h3>Customized by country mirrorlist</h3>
 
     <p>The following form can generate a custom up-to-date
-    <a href="https://wiki.archlinux.org/index.php/Pacman"
+    <a href="https://wiki.archlinux.org/title/Pacman"
         title="ArchWiki: Pacman">pacman</a> mirrorlist based on geography and
     desired protocol(s).  Simply replace the contents of
     <code>/etc/pacman.d/mirrorlist</code> with your generated list.

--- a/templates/public/art.html
+++ b/templates/public/art.html
@@ -11,7 +11,7 @@
     <h3>Logos for Press Usage</h3>
 
     <p>The following Arch Linux logos are available for press and other use, subject to
-    the restrictions of our <a href="https://wiki.archlinux.org/index.php/DeveloperWiki:TrademarkPolicy"
+    the restrictions of our <a href="https://wiki.archlinux.org/title/DeveloperWiki:TrademarkPolicy"
         title="Arch Linux Trademark Policy">trademark policy</a>.</p>
 
     <p><strong>Two-color standard version</strong><br />

--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -29,7 +29,7 @@
         {% if release.version %}<li><strong>Current Release:</strong> {{ release.version }}</li>{% endif %}
         {% if release.kernel_version %}<li><strong>Included Kernel:</strong> {{ release.kernel_version }}</li>{% endif %}
         {% if release.torrent_data %}<li><strong>ISO Size:</strong> {{ release.torrent.file_length|filesizeformat }}</li>{% endif %}
-        <li><a href="https://wiki.archlinux.org/index.php/Installation_guide">Installation Guide</a></li>
+        <li><a href="https://wiki.archlinux.org/title/Installation_guide">Installation Guide</a></li>
         <li><strong>Resources:</strong>
             <ul>
                 <li><a href="https://bugs.archlinux.org/index.php?project=6"
@@ -125,7 +125,7 @@
     {% endcache %}
 
     <p>If you want to become an Official Arch Linux Mirror please follow the
-    instructions listed <a href="https://wiki.archlinux.org/index.php/DeveloperWiki:NewMirrors">here</a>.</p>
+    instructions listed <a href="https://wiki.archlinux.org/title/DeveloperWiki:NewMirrors">here</a>.</p>
 
 </div>
 {% endblock %}

--- a/templates/public/index.html
+++ b/templates/public/index.html
@@ -114,7 +114,7 @@
             title="Community documentation">Wiki</a></li>
         <li><a href="https://man.archlinux.org/"
             title="All manpages from Arch packages">Manual Pages</a></li>
-        <li><a href="https://wiki.archlinux.org/index.php/Installation_guide"
+        <li><a href="https://wiki.archlinux.org/title/Installation_guide"
             title="Installation guide">Installation Guide</a></li>
     </ul>
 
@@ -122,11 +122,11 @@
     <ul>
         <li><a href="https://mailman.archlinux.org/mailman/listinfo/"
             title="Community and developer mailing lists">Mailing Lists</a></li>
-        <li><a href="https://wiki.archlinux.org/index.php/IRC_channels"
+        <li><a href="https://wiki.archlinux.org/title/IRC_channels"
             title="Official and regional IRC communities">IRC Channels</a></li>
         <li><a href="https://planet.archlinux.org/"
             title="Arch in the blogosphere">Planet Arch</a></li>
-        <li><a href="https://wiki.archlinux.org/index.php/International_communities"
+        <li><a href="https://wiki.archlinux.org/title/International_communities"
             title="Arch communities in your native language">International Communities</a></li>
     </ul>
 
@@ -155,13 +155,13 @@
 
     <h4>Development</h4>
     <ul>
-        <li><a href="https://wiki.archlinux.org/index.php/Getting_involved"
+        <li><a href="https://wiki.archlinux.org/title/Getting_involved"
             title="Getting involved">Getting involved</a></li>
         <li><a href="https://projects.archlinux.org/"
             title="Official Arch projects (git)">Projects in Git</a></li>
         <li><a href="{% url 'page-svn' %}"
             title="View SVN entries for packages">SVN Repositories</a></li>
-        <li><a href="https://wiki.archlinux.org/index.php/DeveloperWiki"
+        <li><a href="https://wiki.archlinux.org/title/DeveloperWiki"
             title="Developer Wiki articles">Developer Wiki</a></li>
         <li><a href="/groups/"
             title="View the available package groups">Package Groups</a></li>
@@ -186,7 +186,7 @@
 
     <h4>More Resources</h4>
     <ul>
-        <li><a href="https://wiki.archlinux.org/index.php/Arch_Linux_press_coverage"
+        <li><a href="https://wiki.archlinux.org/title/Arch_Linux_press_coverage"
             title="Arch Linux in the media">Press Coverage</a></li>
         <li><a href="{% url 'page-art' %}" title="Arch logos and other artwork for promotional use">Logos &amp; Artwork</a></li>
         <li><a href="{% url 'news-list' %}" title="News Archives">News Archives</a></li>

--- a/templates/public/svn.html
+++ b/templates/public/svn.html
@@ -5,7 +5,7 @@
     <h2 class="title">SVN Repositories</h2>
     <p>
     The PKGBUILD files can be fetched via the ABS utility. To learn more
-    about ABS, see <a href="https://wiki.archlinux.org/index.php/ABS">the ABS wiki page</a>.
+    about ABS, see <a href="https://wiki.archlinux.org/title/ABS">the ABS wiki page</a>.
     </p>
     <p>The SVN repositories have been cloned into git repositories and can be
     viewed via the cgit interface.

--- a/templates/releng/netboot.html
+++ b/templates/releng/netboot.html
@@ -61,7 +61,7 @@ For details, check out the <a href="https://aur.archlinux.org/packages/ipxe-netb
 
 <h3>More information</h3>
 
-<p>For detailed usage instructions, check out the <a href="https://wiki.archlinux.org/index.php/Netboot">netboot wiki page</a>.
+<p>For detailed usage instructions, check out the <a href="https://wiki.archlinux.org/title/Netboot">netboot wiki page</a>.
 
 </div>
 {% endblock %}


### PR DESCRIPTION
Done with: find -type f -exec sed -Ee ':wiki.archlinux.org: s:(wiki.archlinux.org)/index.php/:\1/title/:g' -i {} \;

Fix #343

[1] https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/335