### PR TITLE
Update mailing list address

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -184,7 +184,7 @@ SECRET_KEY = '00000000000000000000000000000000000000000000000'
 MAILMAN_PASSWORD = ''
 
 # Announcements email address
-ANNOUNCE_EMAIL = 'arch-announce@archlinux.org'
+ANNOUNCE_EMAIL = 'arch-announce@lists.archlinux.org'
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
All the arch-x@archlinux.org -> arch-x@lists.archlinux.org aliases will
be dropped soon[1].

[1] https://lists.archlinux.org/pipermail/arch-dev-public/2021-June/030462.html