### PR TITLE
Allow to download sig from "download from mirror"

### DIFF
--- a/packages/urls.py
+++ b/packages/urls.py
@@ -17,6 +17,7 @@ package_patterns = [
     url(r'^signoff/revoke/$', signoff.signoff_package, {'revoke': True}),
     url(r'^signoff/options/$', signoff.signoff_options),
     url(r'^download/$', display.download),
+    url(r'^download.sig/$', display.download, {'sig': True}),
     url(r'^sonames/$', display.sonames),
     url(r'^sonames/json/$', display.sonames_json),
 ]

--- a/packages/views/display.py
+++ b/packages/views/display.py
@@ -243,7 +243,7 @@ def files_json(request, name, repo, arch):
     return HttpResponse(to_json, content_type='application/json')
 
 
-def download(request, name, repo, arch):
+def download(request, name, repo, arch, sig=False):
     pkg = get_object_or_404(Package.objects.normal(),
                             pkgname=name, repo__name__iexact=repo, arch__name=arch)
     url = get_mirror_url_for_download()
@@ -256,6 +256,10 @@ def download(request, name, repo, arch):
     url = '{host}{repo}/os/{arch}/{filename}'.format(host=url.url,
                                                      repo=pkg.repo.name.lower(),
                                                      arch=arch, filename=pkg.filename)
+
+    if sig:
+        url = url + '.sig'
+
     return redirect(url)
 
 # vim: set ts=4 sw=4 et:


### PR DESCRIPTION
Hello !

To fix this, I added a new url pattern that match `download.sig` and call the same `download` function with a new `sig` param to True.

It's been a while since the last time I did some django, so let me know if you'd like to see this fixed another way!

Fixes #356 