### PR TITLE
Allow users to set their own names

### DIFF
--- a/devel/forms.py
+++ b/devel/forms.py
@@ -19,6 +19,10 @@ class ProfileForm(forms.Form):
         label='New Password', required=False, widget=forms.PasswordInput)
     passwd2 = forms.CharField(
         label='Confirm Password', required=False, widget=forms.PasswordInput)
+    first_name = forms.CharField(
+        label='First name', required=True)
+    last_name = forms.CharField(
+        label='Last name', required=False)
 
     def clean(self):
         if self.cleaned_data['passwd1'] != self.cleaned_data['passwd2']:
@@ -36,7 +40,7 @@ class UserProfileForm(forms.ModelForm):
 
     class Meta:
         model = UserProfile
-        exclude = ('allowed_repos', 'user', 'latin_name', 'repos_auth_token')
+        exclude = ('allowed_repos', 'user', 'repos_auth_token')
 
 
 class NewUserForm(forms.ModelForm):

--- a/devel/models.py
+++ b/devel/models.py
@@ -14,6 +14,8 @@ from planet.models import Feed
 
 
 class UserProfile(models.Model):
+    latin_name = models.CharField(
+        max_length=255, null=True, blank=True, help_text="Latin-form name; used only for non-Latin full names")
     notify = models.BooleanField(
         "Send notifications",
         default=True,
@@ -49,8 +51,6 @@ class UserProfile(models.Model):
         upload_to='devs', default='devs/silhouette.png', help_text="Ideally 125px by 125px")
     user = models.OneToOneField(User, related_name='userprofile', on_delete=models.CASCADE)
     allowed_repos = models.ManyToManyField('main.Repo', blank=True)
-    latin_name = models.CharField(
-        max_length=255, null=True, blank=True, help_text="Latin-form name; used only for non-Latin full names")
     rebuilderd_updates = models.BooleanField(
         default=False, help_text='Receive reproducible build package updates')
     repos_auth_token = models.CharField(max_length=32, null=True, blank=True)

--- a/devel/views.py
+++ b/devel/views.py
@@ -247,7 +247,11 @@ def change_profile(request):
 
             return HttpResponseRedirect('/devel/')
     else:
-        form = ProfileForm(initial={'email': request.user.email})
+        form = ProfileForm(initial={
+            'email': request.user.email,
+            'first_name': request.user.first_name,
+            'last_name': request.user.last_name,
+        })
         profile_form = UserProfileForm(instance=profile)
     return render(request, 'devel/profile.html',
                   {'form': form,


### PR DESCRIPTION
Users should be able to set their own names as they see fit, since names
change for any number of reasons, and there's no sense in allowing them
to be registered with whatever name they give but then require DevOps to
update it if it for whatever reason needs to be updated.

This will hopefully also lead to a better visibility of the latin name
field, allowing staff members whose names are properly written in
non-latin scripts to have their names properly represented.