### PR TITLE
devel/views: Actually save first and last names when they change

### DIFF
--- a/devel/views.py
+++ b/devel/views.py
@@ -234,6 +234,8 @@ def change_profile(request):
                                        instance=profile)
         if form.is_valid() and profile_form.is_valid():
             request.user.email = form.cleaned_data['email']
+            request.user.first_name = form.cleaned_data['first_name']
+            request.user.last_name = form.cleaned_data['last_name']
             if form.cleaned_data['passwd1']:
                 request.user.set_password(form.cleaned_data['passwd1'])
             with transaction.atomic():


### PR DESCRIPTION
Commit e4b211e8 (Allow users to set their own names, 2021-10-14) tried
to allow users to set their own names.  It correctly handles the latin
name field, but it doesn't end up actually saving changes to the first
and last name fields.

Signed-off-by: Johannes Löthberg <johannes@kyriasis.com>