### PR TITLE
Extended netboot_info + replaced hardcoded url

### DIFF
--- a/releng/views.py
+++ b/releng/views.py
@@ -10,6 +10,7 @@ from django.conf import settings
 
 from .models import Release
 from mirrors.models import MirrorUrl
+from main.models import Package
 
 
 class ReleaseListView(ListView):
@@ -90,7 +91,11 @@ def netboot_config(request):
 
 
 def netboot_info(request):
-    return render(request, "releng/netboot.html",
+    ipxepkg = Package.objects.get(pkgname='ipxe')
+    context = {
+        'pkg': ipxepkg
+    }
+    return render(request, "releng/netboot.html", context,
                   {'security_banner':  settings.NETBOOT_SECURITY_BANNER})
 
 # vim: set ts=4 sw=4 et:

--- a/releng/views.py
+++ b/releng/views.py
@@ -93,11 +93,12 @@ def netboot_config(request):
 def netboot_info(request):
     try:
         ipxepkg = Package.objects.get(pkgname='ipxe')
-        context = {
-            'pkg': ipxepkg
-        }
     except Package.DoesNotExist:
         ipxepkg = None
+
+    context = {
+        'pkg': ipxepkg
+    }
     return render(request, "releng/netboot.html", context,
                   {'security_banner':  settings.NETBOOT_SECURITY_BANNER})
 

--- a/releng/views.py
+++ b/releng/views.py
@@ -91,10 +91,13 @@ def netboot_config(request):
 
 
 def netboot_info(request):
-    ipxepkg = Package.objects.get(pkgname='ipxe')
-    context = {
-        'pkg': ipxepkg
-    }
+    try:
+        ipxepkg = Package.objects.get(pkgname='ipxe')
+        context = {
+            'pkg': ipxepkg
+        }
+    except Package.DoesNotExist:
+        ipxepkg = None
     return render(request, "releng/netboot.html", context,
                   {'security_banner':  settings.NETBOOT_SECURITY_BANNER})
 

--- a/templates/releng/netboot.html
+++ b/templates/releng/netboot.html
@@ -57,7 +57,7 @@ protection/authentication.
 </ul>
 
 <p>You can build your own iPXE images compatible with netboot.
-For details, check out the <a href="https://archlinux.org/packages/community/x86_64/ipxe/">ipxe package</a>.</p>
+For details, check out the <a href="{{ pkg.get_full_url }}">ipxe package</a>.</p>
 
 <h3>More information</h3>
 


### PR DESCRIPTION
This should resolve #364. Extended netboot_info to get ipxe package and pass along to netboot template.