### PR TITLE
Added a JSON search endpoint for groups. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ collected_static/
 testing/
 env/
 htmlcov
+*.tar.gz
 
 .mypy_cache/
 

--- a/packages/urls_groups.py
+++ b/packages/urls_groups.py
@@ -1,8 +1,10 @@
 from django.urls import re_path, path
+from packages.views import search
 from packages.views.display import groups, group_details
 
 urlpatterns = [
     path('', groups, name='groups-list'),
+    path('search/json/', search.group_search_json),
     re_path(r'^(?P<arch>[A-z0-9]+)/$', groups),
     re_path(r'^(?P<arch>[A-z0-9]+)/(?P<name>[^ /]+)/$', group_details),
 ]


### PR DESCRIPTION
The result from the group search is all packages that belong to a specific group.
It could probably have been baked into the package search via `https://archlinux.org/packages/search/json/?group=gnome`.
But I would expect the endpoints to be identical across views so I added it under `groups/`.