### PR TITLE
Fix pip install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+git://github.com/fredj/cssmin.git@master#egg=cssmin
+-e git+https://github.com/fredj/cssmin.git@master#egg=cssmin
 Django==4.0.2
 IPy==1.1
 Markdown==3.3.4


### PR DESCRIPTION
The unauthenticated `git://` protocol has been disable on GitHub[^1] and we
need to use `https://` or `git@github.com:<user>/<repo>` to pull a repository.

[^1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/