### PR TITLE
Leave descriptions out of todolist overview tables

### DIFF
--- a/templates/devel/index.html
+++ b/templates/devel/index.html
@@ -128,7 +128,6 @@
                 <th>Name</th>
                 <th>Creation Date</th>
                 <th>Creator</th>
-                <th>Description</th>
                 <th>Package Count</th>
                 <th>Incomplete Count</th>
                 <th>Kind</th>
@@ -141,7 +140,6 @@
                         title="View todo list: {{ todo.name }}">{{ todo.name }}</a></td>
                 <td>{{ todo.created|date }}</td>
                 <td>{{ todo.creator.get_full_name }}</td>
-                <td class="wrap">{{ todo.description|urlize|truncatewords:"50" }}</td>
                 <td>{{ todo.pkg_count }}</td>
                 <td>{{ todo.incomplete_count }}</td>
                 <td>{{ todo.kind_str }}</td>

--- a/templates/todolists/list.html
+++ b/templates/todolists/list.html
@@ -26,7 +26,6 @@
                 <th>Name</th>
                 <th>Creation Date</th>
                 <th>Creator</th>
-                <th>Description</th>
                 <th>Package Count</th>
                 <th>Incomplete Count</th>
                 <th>Kind</th>
@@ -40,7 +39,6 @@
                         title="View todo list: {{ list.name }}">{{ list.name }}</a></td>
                 <td>{{ list.created|date }}</td>
                 <td>{{ list.creator.get_full_name }}</td>
-                <td class="wrap">{{ list.description|urlize }}</td>
                 <td>{{ list.pkg_count }}</td>
                 <td>{{ list.incomplete_count }}</td>
                 <td>{{ list.kind_str }}</td>


### PR DESCRIPTION
With long descriptions the todolist overview table gets unwieldy. The
todo title should suffice for these views, and the description should
only be shown in the todo details page.