### PR TITLE
Add an id attribute to the Checksums heading to allow linking to it directly

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -106,7 +106,7 @@
 
     <p><code>sq verify --signer-cert release-key.pgp --detached archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></p>
 
-    <h4>Checksums</h4>
+    <h4 id="checksums">Checksums</h4>
 
     <p>File integrity checksums for the latest releases can be found below:</p>
 


### PR DESCRIPTION
This would allow avoiding such kludgy text as "under Checksums in the [Download](https://archlinux.org/download/) page" in https://wiki.archlinux.org/title/Installation_guide#Verify_signature.