### PR TITLE
Add bootstrap tarball PGP signature to the downloads page

### DIFF
--- a/releng/models.py
+++ b/releng/models.py
@@ -47,6 +47,9 @@ class Release(models.Model):
     def iso_url(self):
         return "iso/%s/archlinux-%s-x86_64.iso" % (self.version, self.version)
 
+    def tarball_url(self):
+        return "iso/%s/archlinux-bootstrap-%s-x86_64.tar.gz" % (self.version, self.version)
+
     def magnet_uri(self):
         query = [
             ('dn', "archlinux-%s-x86_64.iso" % self.version),

--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -112,7 +112,9 @@
 
     <ul>
         <li><a href="https://archlinux.org/{{ release.iso_url }}.sig"
-            title="PGP signature">PGP signature</a></li>
+            title="ISO PGP signature">ISO PGP signature</a></li>
+        <li><a href="https://archlinux.org/{{ release.tarball_url }}.sig"
+            title="Bootstrap tarball PGP signature">Bootstrap tarball PGP signature</a></li>
         {% if release.pgp_key %}<li><strong>PGP fingerprint:</strong> {% pgp_key_link release.pgp_key %}</li>{% endif %}
         {% if release.wkd_email %}<li><strong>WKD Lookup: </strong><code>gpg --auto-key-locate clear,wkd -v --locate-external-key {{ release.wkd_email }}</code></li>{% endif %}
         {% if release.sha256_sum %}<li><strong>SHA256:</strong> {{ release.sha256_sum }}</li>{% endif %}


### PR DESCRIPTION
Previosly it was not linked from anywhere, making one think that it can only be downloaded from the mirrors which is not safe.