### PR TITLE
Make monospaced text the same size as the rest of the text

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -67,13 +67,13 @@ ul {
     }
 
 code {
-    font: 1.2em monospace;
+    font-family: monospace, monospace;
     background: #ffd;
     padding: 0.15em 0.25em;
 }
 
 pre {
-    font: 1.2em monospace;
+    font-family: monospace, monospace;
     border: 1px solid #bdb;
     background: #dfd;
     padding: 0.5em;


### PR DESCRIPTION
`1.2em monospace` is slightly smaller than 1em of any other text.
Use `monospace, monospace` as the font to workaround the browser quirk instead of explicitly setting the font size.