### PR TITLE
Change the `Download From Mirror` link to skip one redirect

### DIFF
--- a/templates/packages/package_details.html
+++ b/templates/packages/package_details.html
@@ -47,7 +47,7 @@
                     target="_blank"
                     >(?)</a></li>
                 {% endif %}
-                <li><a href="download" rel="nofollow" title="Download {{ pkg.pkgname }} from mirror">Download From Mirror</a></li>
+                <li><a href="download/" rel="nofollow" title="Download {{ pkg.pkgname }} from mirror">Download From Mirror</a></li>
             </ul>
 
             {% if perms.main.change_package %}


### PR DESCRIPTION
Currently we link to `https://archlinux.org/packages/core/any/base/download` which redirects again before redirecting to a mirror. It's likely an nginx rule somewhere, adding this slash to the link makes the download _slightly faster_.

```
% curl -I 'https://archlinux.org/packages/core/any/base/download'
HTTP/2 301 
server: nginx
date: Wed, 03 Aug 2022 11:35:19 GMT
content-type: text/html; charset=utf-8
content-length: 0
location: /packages/core/any/base/download/
x-cache-status: MISS
strict-transport-security: max-age=31536000; includeSubdomains; preload
```

```
% curl -I 'https://archlinux.org/packages/core/any/base/download/'
HTTP/2 302 
server: nginx
date: Wed, 03 Aug 2022 11:35:38 GMT
content-type: text/html; charset=utf-8
content-length: 0
location: https://mirror.f4st.host/archlinux/core/os/x86_64/base-3-1-any.pkg.tar.zst
content-security-policy: img-src 'self' data:; frame-ancestors 'none'; script-src 'self'; form-action 'self'; default-src 'self'; base-uri 'none'
x-content-type-options: nosniff
referrer-policy: strict-origin
cross-origin-opener-policy: same-origin
x-frame-options: DENY
x-cache-status: MISS
strict-transport-security: max-age=31536000; includeSubdomains; preload
```