### PR TITLE
todolists: restore ordering by status in list view

### DIFF
--- a/templates/todolists/list.html
+++ b/templates/todolists/list.html
@@ -58,7 +58,7 @@
 <script type="text/javascript" src="{% static "archweb.js" %}"></script>
 <script type="text/javascript" nonce={{ CSP_NONCE }}>
 $(document).ready(function() {
-    $(".results").tablesorter({widgets: ['zebra'], sortList: [[7, 1], [1, 1]]});
+    $(".results").tablesorter({widgets: ['zebra'], sortList: [[6, 1], [1, 1]]});
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
After removing the description column, status has become the 7th column
instead of the 8th; fix the tablesorter call to use the correct number.

Fixes: 74e24ff4e6a9 ("Leave descriptions out of todolist overview tables")