### PR TITLE
Link to "USB flash installation medium" on the wiki for instructions on preparing a USB flash drive

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -21,8 +21,8 @@
     <h3>Release Info</h3>
 
     <p>The image can be burned to a CD, mounted as an ISO file,
-    or be directly written to a USB stick using a utility like <code>dd</code>. It
-    is intended for new installations only; an existing Arch Linux system
+    or be <a href="https://wiki.archlinux.org/title/USB_flash_installation_medium">directly written to a USB flash drive</a>.
+    It is intended for new installations only; an existing Arch Linux system
     can always be updated with <code>pacman -Syu</code>.</p>
 
     <ul>


### PR DESCRIPTION
Link to https://wiki.archlinux.org/title/USB_flash_installation_medium instead of vaguely mentioning that `dd` can be used.