### PR TITLE
Fix SCM link of kde-unstable packages

### DIFF
--- a/main/templatetags/details_link.py
+++ b/main/templatetags/details_link.py
@@ -20,8 +20,12 @@ def details_link(pkg):
 
 @register.simple_tag
 def scm_link(package, operation):
-    parts = (package.repo.svn_root, operation, package.pkgbase)
-    linkbase = ("https://github.com/archlinux/svntogit-%s/%s/packages/%s/trunk")
+    if package.repo.name == "KDE-Unstable":
+        branch = "kde-unstable"
+    else:
+        branch = "trunk"
+    parts = (package.repo.svn_root, operation, package.pkgbase, branch)
+    linkbase = ("https://github.com/archlinux/svntogit-%s/%s/packages/%s/%s")
     return linkbase % tuple(urlquote(part.encode('utf-8')) for part in parts)
 
 


### PR DESCRIPTION
They are currently pointing to trunk, which isn't correct.