### PR TITLE
Note the requirement of DHT for BitTorrent downloads

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -56,7 +56,9 @@
 
     <p>If you can spare the bytes, please leave the client open after your
     download is finished, so you can seed it back to others.
-    <em>A web-seed capable client is recommended for fastest download speeds.</em></p>
+    <br/>
+    <strong>A DHT capable client is required.</strong>
+    A WebSeed capable client is recommended for fastest download speeds.</p>
 
     {% if release %}<ul>
         <li><a href="{{ release.magnet_uri }}"

--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -77,7 +77,7 @@
 
     <p>Vagrant images for libvirt and virtualbox are available on the <a href="https://app.vagrantup.com/archlinux/boxes/archlinux">Vagrant Cloud</a>. You can bootstrap the image with the following commands:</p>
     <code>vagrant init archlinux/archlinux</code>
-    </br>
+    <br/>
     <code>vagrant up</code>
 
     <h3>Docker image</h3>

--- a/templates/releng/release_list.html
+++ b/templates/releng/release_list.html
@@ -17,9 +17,9 @@
     the version of each release to read any additional notes or details about
     each release.</p>
     <p>Torrents and magnet URIs are available to download the releases.
-    Releases listed as not available may still be seeded by peers, but are no
-    longer registered via the official Arch Linux torrent tracker. We always
-    recommend running the latest available release.</p>
+    Releases listed as not available may still be seeded by peers, but may no
+    longer be available from WebSeeds. We always recommend running the latest
+    available release.</p>
 
     <table id="release-table" class="results">
         <thead>


### PR DESCRIPTION
* Some BitTorrent clients need additional configuration to enable DHT. See https://bugs.archlinux.org/task/71368 and https://bbs.archlinux.org/viewtopic.php?pid=1982176#p1982176.
* Mention WebSeeds instead of the decomissioned torrent tracker in releng release list