### PR TITLE
archlinux.ipxe: Turn on OpenSSL CMS signature varification for root file system

### DIFF
--- a/templates/releng/archlinux.ipxe
+++ b/templates/releng/archlinux.ipxe
@@ -132,7 +132,7 @@ initrd ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img || goto failed_downl
 imgverify intel-ucode.img ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/x86_64/initramfs-linux.img || goto failed_download
 imgverify initramfs-linux.img ${mirrorurl}iso/${release}/arch/boot/x86_64/initramfs-linux.img.ipxe.sig || goto failed_verify
-imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=initramfs-linux.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y ${extrabootoptions}
+imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=initramfs-linux.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y cms_verify=y ${extrabootoptions}
 boot || goto failed_boot
 
 :failed_download


### PR DESCRIPTION
See https://gitlab.archlinux.org/mkinitcpio/mkinitcpio-archiso/-/merge_requests/24 for details.

After there have been at least three releases with OpenSSL signed netboot artifacts, the GPG-based verification option `verify=y` can be removed.

/cc @dvzrv @Torxed
