### PR TITLE
archlinux.ipxe: do not perform GPG signature verification for the root file system image

### DIFF
--- a/templates/releng/archlinux.ipxe
+++ b/templates/releng/archlinux.ipxe
@@ -132,7 +132,7 @@ initrd ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img || goto failed_downl
 imgverify intel-ucode.img ${mirrorurl}iso/${release}/arch/boot/intel-ucode.img.ipxe.sig || goto failed_verify
 initrd ${mirrorurl}iso/${release}/arch/boot/x86_64/initramfs-linux.img || goto failed_download
 imgverify initramfs-linux.img ${mirrorurl}iso/${release}/arch/boot/x86_64/initramfs-linux.img.ipxe.sig || goto failed_verify
-imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=initramfs-linux.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch verify=y cms_verify=y ${extrabootoptions}
+imgargs vmlinuz-linux initrd=amd-ucode.img initrd=intel-ucode.img initrd=initramfs-linux.img archiso_http_srv=${mirrorurl}iso/${release}/ archisobasedir=arch cms_verify=y ${extrabootoptions}
 boot || goto failed_boot
 
 :failed_download


### PR DESCRIPTION
Now that there have been three ISO releases with OpenSSL signed root file system image, the GPG-based verification option `verify=y` can be removed.

Doing this will allow releasing official ISOs without a GPG signed root file system image. The past few ISOs have been signed with an "Ephemeral Signing Key", so nothing of value will be lost.
This was done because it is complicated to run `mkarchiso` as root while passing it the user's GPG keys.

The envisioned future automated release process would also benefit by not tangling itself with GPG and only rely on code signing certificates.

Follow-up to commit 248908d4223b9ccf274fe19175b91d365a8501f8

/cc @dvzrv @Torxed 