### PR TITLE
Add 'out-of-date' title to flagged packages in search page

### DIFF
--- a/templates/packages/search.html
+++ b/templates/packages/search.html
@@ -63,7 +63,7 @@
                 <td>{{ pkg.repo.name|capfirst }}</td>
                 <td>{% pkg_details_link pkg %}</td>
                 {% if pkg.flag_date %}
-                <td><span class="flagged">{{ pkg.full_version }}</span></td>
+                <td><span class="flagged" title="Flagged out-of-date">{{ pkg.full_version }}</span></td>
                 {% else %}
                 <td>{{ pkg.full_version }}</td>
                 {% endif %}
@@ -110,7 +110,7 @@
                     <td>{{ pkg.repo.name|capfirst }}</td>
                     <td>{% pkg_details_link pkg %}</td>
                     {% if pkg.flag_date %}
-                    <td><span class="flagged">{{ pkg.full_version }}</span></td>
+                    <td><span class="flagged" title="Flagged out-of-date">{{ pkg.full_version }}</span></td>
                     {% else %}
                     <td>{{ pkg.full_version }}</td>
                     {% endif %}


### PR DESCRIPTION
This make it clear for those people who are curious about why the version text is in red.