### PR TITLE
Update README for deprecated smtpd with aiosmtpd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,15 @@ For PostgreSQL use packages/sql/update.postgresql_psycopg2.sql
 # Testing SMTP server
 
 To be able to create an account on your test environment an SMTP server is
-required. A simple debugging SMTP server can be setup using Python.
+required. A simple debugging SMTP server can be setup using Python and `aiosmtpd`.
 
-        python -m smtpd -n -c DebuggingServer localhost:1025
+Install `aiosmtpd`
+
+        pip install aiosmtpd
+
+Run the server
+
+        python -m aiosmtpd -n -l localhost:1025
 
 In local\_settings.py add entries to set EMAIL\_HOST to 'localhost' and EMAIL\_PORT to
 1025.


### PR DESCRIPTION
Python's [smtpd](https://docs.python.org/3/library/smtpd.html) will be deprecated in python 3.12. This commit updates archweb's README to include instructions for using
[aiosmtpd](https://aiosmtpd.readthedocs.io/en/latest/cli.html) instead, as recommended by the deprecation notice on python.org.

Fixes https://github.com/archlinux/archweb/issues/453