### PR TITLE
Add link to GitLab forge site

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
                 <li id="anb-packages"><a href="/packages/" title="Arch Package Database">Packages</a></li>
                 <li id="anb-forums"><a href="https://bbs.archlinux.org/" title="Community forums">Forums</a></li>
                 <li id="anb-wiki"><a href="https://wiki.archlinux.org/" title="Community documentation">Wiki</a></li>
+                <li id="anb-forge"><a href="https://gitlab.archlinux.org/" title="Track project and package sources">Forge</a></li>
                 <li id="anb-bugs"><a href="https://bugs.archlinux.org/" title="Report and track bugs">Bugs</a></li>
                 <li id="anb-security"><a href="https://security.archlinux.org/" title="Arch Linux Security Tracker">Security</a></li>
                 <li id="anb-aur"><a href="https://aur.archlinux.org/" title="Arch Linux User Repository">AUR</a></li>


### PR DESCRIPTION
The Arch Linux GitLab instance has been public for some time and
especially with package migration to Git is increasingly relevant. Even
without packages lots of Arch projects are tracked there and eventually
it will eclipse Flyspray in relevance for collecting bug reports. Hence
placing it near and before the "Bugs" link to Flyspray.
