### PR TITLE
template: update outdated links on the download page

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -32,8 +32,8 @@
         <li><a href="https://wiki.archlinux.org/title/Installation_guide">Installation Guide</a></li>
         <li><strong>Resources:</strong>
             <ul>
-                <li><a href="https://bugs.archlinux.org/index.php?project=6"
-                    title="Arch Linux Bugtracker:Release Engineering">Bug Tracker</a></li>
+                <li><a href="https://gitlab.archlinux.org/archlinux/archiso/-/issues"
+                    title="Arch Linux Gitlab:Archiso">Issue tracker</a></li>
                 <li><a href="https://lists.archlinux.org/mailman3/lists/arch-releng.lists.archlinux.org/"
                     title="Arch Linux Release Engineering mailing list">Mailing List</a></li>
             </ul>
@@ -89,7 +89,7 @@
 
     <h3>VM images</h3>
 
-    <p>Official virtual machine images are available for download on our <a href="https://gitlab.archlinux.org/archlinux/arch-boxes/-/jobs/artifacts/master/browse/output?job=build:secure">GitLab instance</a>, more information is available in the <a href="https://gitlab.archlinux.org/archlinux/arch-boxes/">README</a>.</p>
+    <p>Official virtual machine images are available for download on our <a href="https://gitlab.archlinux.org/archlinux/arch-boxes/-/packages">GitLab instance</a>, more information is available in the <a href="https://gitlab.archlinux.org/archlinux/arch-boxes/">README</a>.</p>
 
     <h3>HTTP Direct Downloads</h3>
 


### PR DESCRIPTION
There are two outdated links on the download page:

- link to the releng/iso bugtracker
- link to the built vm images

fixes https://bugs.archlinux.org/task/79331
fixes https://bugs.archlinux.org/task/78321
