### PR TITLE
templates: update trademark policy URL

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -83,7 +83,7 @@
                 <a href="mailto:anthraxx@archlinux.org" title="Contact Levente Polyák">Levente Polyák</a>.</p>
 
             <p>The Arch Linux name and logo are recognized
-            <a href="https://wiki.archlinux.org/title/DeveloperWiki:TrademarkPolicy"
+            <a href="https://terms.archlinux.org/docs/trademark-policy/"
                 title="Arch Linux Trademark Policy">trademarks</a>. Some rights reserved.</p>
 
             <p>The registered trademark Linux® is used pursuant to a sublicense from LMI,

--- a/templates/public/art.html
+++ b/templates/public/art.html
@@ -11,7 +11,7 @@
     <h3>Logos for Press Usage</h3>
 
     <p>The following Arch Linux logos are available for press and other use, subject to
-    the restrictions of our <a href="https://wiki.archlinux.org/title/DeveloperWiki:TrademarkPolicy"
+    the restrictions of our <a href="https://terms.archlinux.org/docs/trademark-policy/"
         title="Arch Linux Trademark Policy">trademark policy</a>.</p>
 
     <p><strong>Two-color standard version</strong><br />


### PR DESCRIPTION
Arch Linux trademark policy was moved from ArchWiki to https://terms.archlinux.org/

Related to https://gitlab.archlinux.org/archlinux/service-agreements/-/issues/5

/cc @christian-heusel