### PR TITLE
Rename TU to Package Maintainer

### DIFF
--- a/devel/fixtures/staff_groups.json
+++ b/devel/fixtures/staff_groups.json
@@ -16,13 +16,13 @@
 {
     "fields": {
         "group": [
-            "Trusted Users"
+            "Package Maintainers"
         ],
-        "description": "Here are all your friendly Arch Linux Trusted Users who are in charge of the [community] repository.",
+        "description": "Here are all your friendly Arch Linux Package Maintainers who are in charge of the Archlinux's official repositories (aside from [core] / [core-testing].",
         "sort_order": 2,
-        "member_title": "Trusted User",
-        "slug": "trusted-users",
-        "name": "Trusted Users"
+        "member_title": "Package Maintainer",
+        "slug": "package-maintainers",
+        "name": "Package Maintainers"
     },
     "model": "devel.staffgroup",
     "pk": 2
@@ -44,13 +44,13 @@
 {
     "fields": {
         "group": [
-            "Retired Trusted Users"
+            "Retired Package Maintainers"
         ],
-        "description": "Below you can find a list of ex-trusted users (aka fellows). These folks helped make Arch what it is today. Thanks!",
+        "description": "Below you can find a list of ex-package maintainers (aka fellows). These folks helped make Arch what it is today. Thanks!",
         "sort_order": 12,
         "member_title": "Fellow",
-        "slug": "trusted-user-fellows",
-        "name": "Trusted User Fellows"
+        "slug": "package-maintainer-fellows",
+        "name": "Package Maintainer Fellows"
     },
     "model": "devel.staffgroup",
     "pk": 4

--- a/devel/fixtures/staff_groups.json
+++ b/devel/fixtures/staff_groups.json
@@ -18,7 +18,7 @@
         "group": [
             "Package Maintainers"
         ],
-        "description": "Here are all your friendly Arch Linux Package Maintainers who are in charge of the Archlinux's official repositories (aside from [core] / [core-testing].",
+        "description": "Here are all your friendly Arch Linux Package Maintainers who are in charge of the Archlinux's official repositories (aside from [core] / [core-testing]).",
         "sort_order": 2,
         "member_title": "Package Maintainer",
         "slug": "package-maintainers",

--- a/devel/management/commands/retire_user.py
+++ b/devel/management/commands/retire_user.py
@@ -21,7 +21,7 @@ logger.setLevel(logging.WARNING)
 
 MAPPING = {
     'Developers': 'Retired Developers',
-    'Trusted Users': 'Retired Trusted Users',
+    'Package Maintainers': 'Retired Package Maintainers',
     'Support Staff': 'Retired Support Staff',
 }
 

--- a/devel/views.py
+++ b/devel/views.py
@@ -109,7 +109,7 @@ def stats(request):
     return render(request, 'devel/stats.html', page_dict)
 
 
-SELECTED_GROUPS = ['Developers', 'Trusted Users', 'Support Staff']
+SELECTED_GROUPS = ['Developers', 'Package Maintainer', 'Support Staff']
 
 
 @login_required

--- a/devel/views.py
+++ b/devel/views.py
@@ -109,7 +109,7 @@ def stats(request):
     return render(request, 'devel/stats.html', page_dict)
 
 
-SELECTED_GROUPS = ['Developers', 'Package Maintainer', 'Support Staff']
+SELECTED_GROUPS = ['Developers', 'Package Maintainers', 'Support Staff']
 
 
 @login_required

--- a/docs/mirror_access.md
+++ b/docs/mirror_access.md
@@ -2,7 +2,7 @@
 
 Archweb can be used as external authentication provider in combination with
 [ngx_http_auth_request_module](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html).
-A user with a Developer, Trusted User and Support Staff role can generate an
+A user with a Developer, Package Maintainer and Support Staff role can generate an
 access token used in combination with his username on the `/devel/tier0mirror`
 url. The mirror authentication is done against `/devel/mirrorauth` using HTTP
 Basic authentication.

--- a/main/fixtures/groups.json
+++ b/main/fixtures/groups.json
@@ -70,7 +70,7 @@
 },
 {
     "fields": {
-        "name": "Trusted Users",
+        "name": "Package Maintainers",
         "permissions": [
             [
                 "change_package",
@@ -307,7 +307,7 @@
 },
 {
     "fields": {
-        "name": "Retired Trusted Users",
+        "name": "Retired Package Maintainers",
         "permissions": []
     },
     "model": "auth.group",

--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -988,7 +988,7 @@ table td.country {
     stroke-width: 1.5px;
 }
 
-/* dev/TU biographies */
+/* dev/packager biographies */
 #arch-bio-toc {
     width: 75%;
     margin: 0 auto;

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
                     <li><a href="{% url 'admin:index' %}" title="Django Admin Interface">Django Admin</a></li>
                     {% endif %}
                     <li><a href="/devel/profile/" title="Modify your account profile">Profile</a></li>
-                    {% if user|in_groups:'Developers:Trusted Users:Support Staff' %}
+                    {% if user|in_groups:'Developers:Package Maintainers:Support Staff' %}
                     <li><a href="/devel/tier0mirror/" title="Your Tier 0 Mirror information">Tier0 mirror</a></li>
                     {% endif %}
                     <li><a href="/logout/" title="Logout of the developer interface">Logout</a></li>

--- a/templates/devel/profile.html
+++ b/templates/devel/profile.html
@@ -10,7 +10,7 @@
 
     <form id="edit-profile-form" enctype="multipart/form-data" method="post" action="">{% csrf_token %}
         <p><em>Note:</em> This is the public information shown on the developer
-        and/or TU profiles page, so please be appropriate with the information
+        and/or package maintainer profiles page, so please be appropriate with the information
         you provide here.</p>
         <fieldset>
             <p><label>Username:</label>

--- a/templates/planet/index.html
+++ b/templates/planet/index.html
@@ -12,7 +12,7 @@
     <h2>Arch Planet</h2>
 
     <p>Planet <strong>Arch Linux</strong> is a window into the world, work and
-    lives of Arch Linux developers, trusted users and support staff.</p>
+    lives of Arch Linux developers, package maintainers and support staff.</p>
 </div>
 
 <div id="planet">

--- a/templates/public/keys.html
+++ b/templates/public/keys.html
@@ -26,7 +26,7 @@
                 <th>Owner's Signing Key</th>
                 <th>Revoker</th>
                 <th>Revoker's Signing Key</th>
-                <th>Developer/TU Keys Signed</th>
+                <th>Developer/Package Maintainer Keys Signed</th>
             </tr>
         </thead>
         <tbody>
@@ -58,12 +58,12 @@
 <div class="box">
     <h2 id="master-sigs">Master Key Signatures</h2>
 
-    <p>The following table shows all active developers and trusted users along
+    <p>The following table shows all active developers and package maintainers along
     with the status of their personal signing key. A 'Yes' indicates that the
     personal key of the developer is signed by the given master key. A 'No'
     indicates it has not been signed; however, this does not necessarily mean
     the key should not be trusted.</p>
-    <p>All official Arch Linux developers and trusted users should have their
+    <p>All official Arch Linux developers and package maintainers should have their
     key signed by at least three master keys if they are responsible for
     packaging software in the repositories. This is in accordance with the PGP
     <em>web of trust</em> concept. If a user is willing to marginally trust all


### PR DESCRIPTION
In the continuity of the effort started to apply the 'TU --> Package Maintainer' rename to every Arch ressources, here's a PR for archweb :)

Related MRs/Tickets:
- https://gitlab.archlinux.org/archlinux/package-maintainer-bylaws/-/merge_requests/6
- https://gitlab.archlinux.org/archlinux/aurweb/-/merge_requests/755
- https://gitlab.archlinux.org/archlinux/infrastructure/-/issues/533

This PR also updates the few obselete mentions to the [community] repository in the various descriptions