### PR TITLE
Switch bugs.archlinux.org to Gitlab

### DIFF
--- a/main/templatetags/details_link.py
+++ b/main/templatetags/details_link.py
@@ -34,23 +34,14 @@ def scm_link(package, operation: str):
 
 @register.simple_tag
 def bugs_list(package):
-    url = "https://bugs.archlinux.org/"
-    data = {
-        'project': package.repo.bugs_project,
-        'string': package.pkgname,
-    }
-    return link_encode(url, data)
+    pkgbase = urlquote(gitlab_project_name_to_path(package.pkgbase))
+    return f'{settings.GITLAB_PACKAGES_REPO}/{pkgbase}/-/issues'
 
 
 @register.simple_tag
 def bug_report(package):
-    url = "https://bugs.archlinux.org/newtask"
-    data = {
-        'project': package.repo.bugs_project,
-        'product_category': package.repo.bugs_category,
-        'item_summary': '[%s] PLEASE ENTER SUMMARY' % package.pkgname,
-    }
-    return link_encode(url, data)
+    pkgbase = urlquote(gitlab_project_name_to_path(package.pkgbase))
+    return f'{settings.GITLAB_PACKAGES_REPO}/{pkgbase}/-/issues/new'
 
 
 @register.simple_tag

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
                 <li id="anb-packages"><a href="/packages/" title="Arch Package Database">Packages</a></li>
                 <li id="anb-forums"><a href="https://bbs.archlinux.org/" title="Community forums">Forums</a></li>
                 <li id="anb-wiki"><a href="https://wiki.archlinux.org/" title="Community documentation">Wiki</a></li>
-                <li id="anb-bugs"><a href="https://bugs.archlinux.org/" title="Report and track bugs">Bugs</a></li>
+                <li id="anb-gitlab"><a href="https://gitlab.archlinux.org/archlinux" title="GitLab">GitLab</a></li>
                 <li id="anb-security"><a href="https://security.archlinux.org/" title="Arch Linux Security Tracker">Security</a></li>
                 <li id="anb-aur"><a href="https://aur.archlinux.org/" title="Arch Linux User Repository">AUR</a></li>
                 <li id="anb-download"><a href="{% url 'page-download' as pdl %}{{ pdl }}" title="Get Arch Linux">Download</a></li>

--- a/templates/public/feeds.html
+++ b/templates/public/feeds.html
@@ -170,49 +170,29 @@
 
     <h3>Development Feeds</h3>
 
-    <p>Subscribe to any of the following to track bug tickets and feature
-    requests from the <a href="https://bugs.archlinux.org/" title="Arch Linux Bugs">Arch Linux Bugtracker</a>:</p>
+    <p>Subscribe to any of the following to track issues and feature
+    requests from the <a href="https://gitlab.archlinux.org/" title="Arch Linux GitLab">Arch Linux GitLab</a>:</p>
 
     <table class="pretty2">
         <thead>
             <tr>
                 <th>Project</th>
-                <th>Recently Opened Tasks</th>
-                <th>Recently Edited Tasks</th>
-                <th>Recently Closed Tasks</th>
+                <th>Issues</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td>All Projects</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=0" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=0" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=0" class="rss">Feed</a></td>
-            </tr><tr>
-                <td>Arch Linux</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=1" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=1" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=1" class="rss">Feed</a></td>
+                <td>Packages</td>
+                <td><a href="https://gitlab.archlinux.org/groups/archlinux/packaging/packages/-/issues?format=atom" class="rss">Feed</a></td>
             </tr><tr>
                 <td>Release Engineering</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=6" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=6" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=6" class="rss">Feed</a></td>
+                <td><a href="https://gitlab.archlinux.org/archlinux/archiso/-/issues?format=atom" class="rss">Feed</a></td>
             </tr><tr>
                 <td>Pacman Development</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=3" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=3" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=3" class="rss">Feed</a></td>
-            </tr><tr>
-                <td>Community Packages</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=5" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=5" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=5" class="rss">Feed</a></td>
+                <td><a href="https://gitlab.archlinux.org/pacman/pacman/-/issues?format=atom" class="rss">Feed</a></td>
             </tr><tr>
                 <td>AUR</td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;project=2" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=edit&amp;project=2" class="rss">Feed</a></td>
-                <td><a href="https://bugs.archlinux.org/feed.php?feed_type=rss2&amp;topic=clo&amp;project=2" class="rss">Feed</a></td>
+                <td><a href="https://gitlab.archlinux.org/archlinux/aurweb/-/issues?format=atom" class="rss">Feed</a></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Our old flyspray bugtracker is deprecated and we migrated to Gitlab where now all packaging and project issues should be created. As it doesn't make a lot of sense to keep bugs in the header update it to Gitlab.

![image](https://github.com/archlinux/archweb/assets/67428/3aacaa56-380c-4e50-a191-7e5d5ccc1f92)
