### PR TITLE
templates/public/download.html: update checksum and signature list and verification

### DIFF
--- a/releng/models.py
+++ b/releng/models.py
@@ -49,6 +49,9 @@ class Release(models.Model):
     def tarball_url(self):
         return "iso/%s/archlinux-bootstrap-%s-x86_64.tar.gz" % (self.version, self.version)
 
+    def dir_url(self):
+        return "iso/%s" % (self.version)
+
     def magnet_uri(self):
         query = [
             ('dn', "archlinux-%s-x86_64.iso" % self.version),

--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -95,35 +95,49 @@
 
     <p>In addition to the BitTorrent links above, install images can also be
     downloaded via HTTP from the mirror sites listed below. Please
-    ensure the download image matches the checksum from the sha256sums.txt or
-    b2sums.txt file in the same directory as the image.</p>
+    ensure the download image matches the checksum from the <code>sha256sums.txt</code> or <code>b2sums.txt</code> file linked below.</p>
 
-    <p><code>b2sum -c b2sums.txt</code></p>
-
-    <p>The release signing key can be downloaded with WKD:</p>
-
-    <p><code>sq network wkd fetch {{ release.wkd_email }} -o release-key.pgp</code></p>
-
-    <p>With this key the signature can be verified like this:</p>
-
-    <p><code>sq verify --signer-file release-key.pgp --detached archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></p>
-
-    <h4 id="checksums">Checksums</h4>
-
-    <p>File integrity checksums for the latest releases can be found below:</p>
+    <h4 id="checksums">Checksums and signatures</h4>
+    <p>File integrity checksums and PGP signatures for the latest releases can be found below:</p>
 
     <ul>
-        <li><a href="https://archlinux.org/{{ release.iso_url }}.sig"
-            title="ISO PGP signature">ISO PGP signature</a></li>
-        <li><a href="https://archlinux.org/{{ release.tarball_url }}.sig"
-            title="Bootstrap tarball PGP signature">Bootstrap tarball PGP signature</a></li>
-        {% if release.pgp_key %}<li><strong>PGP fingerprint:</strong> {% pgp_key_link release.pgp_key %}</li>{% endif %}
-        {% if release.wkd_email %}<li><strong>WKD Lookup: </strong><code>gpg --auto-key-locate clear,wkd -v --locate-external-key {{ release.wkd_email }}</code></li>{% endif %}
-        {% if release.sha256_sum %}<li><strong>SHA256:</strong> {{ release.sha256_sum }}</li>{% endif %}
-        {% if release.b2_sum %}<li><strong>BLAKE2b:</strong> {{ release.b2_sum }}</li>{% endif %}
-        {% if release.sha1_sum %}<li><strong>SHA1:</strong> {{ release.sha1_sum }}</li>{% endif %}
-        {% if release.md5_sum %}<li><strong>MD5:</strong> {{ release.md5_sum }}</li>{% endif %}
+        <li>ISO
+            <ul>
+                <li><a href="https://archlinux.org/{{ release.iso_url }}.sig"
+                    title="ISO PGP signature">PGP signature</a></li>
+                {% if release.pgp_key %}<li><strong>PGP fingerprint:</strong> {% pgp_key_link release.pgp_key %}</li>{% endif %}
+                {% if release.sha256_sum %}<li><strong>SHA256:</strong> {{ release.sha256_sum }}</li>{% endif %}
+                {% if release.b2_sum %}<li><strong>BLAKE2b:</strong> {{ release.b2_sum }}</li>{% endif %}
+                {% if release.sha1_sum %}<li><strong>SHA1:</strong> {{ release.sha1_sum }}</li>{% endif %}
+                {% if release.md5_sum %}<li><strong>MD5:</strong> {{ release.md5_sum }}</li>{% endif %}
+            </ul>
+        </li>
+        <li>Bootstrap tarball
+            <ul>
+                <li><a href="https://archlinux.org/{{ release.tarball_url }}.sig"
+                    title="Bootstrap tarball PGP signature">PGP signature</a></li>
+            </ul>
+            {% if release.sha256_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha256sums.txt">sha256sums.txt</a></li>{% endif %}
+            {% if release.b2_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/b2sums.txt">b2sums.txt</a></li>{% endif %}
+            {% if release.sha1_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha1sums.txt">sha1sums.txt</a></li>{% endif %}
+            {% if release.md5_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/md5sums.txt">md5sums.txt</a></li>{% endif %}
+        </li>
     </ul>
+
+    <h5>Download verification</h4>
+
+    <p>Verify the BLAKE2b checksums as follows: <pre><code>$ b2sum -c b2sums.txt</code></pre></p>
+
+    <p>To verify the PGP signature using Sequoia, first download the release signing key from WKD:<br/>
+    <pre><code>$ sq network wkd fetch {{ release.wkd_email }} -o release-key.pgp</code></pre>
+
+    With this signing key, verify the signature:
+    <pre><code>$ sq verify --signer-file release-key.pgp --detached archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre></p>
+
+    <p>Alternatively, using GnuPG, download the signing key from WKD:
+    <pre><code>$ gpg --auto-key-locate clear,wkd -v --locate-external-key {{ release.wkd_email }}</code></pre>
+    Verify the signature:
+    <pre><code>$ gpg --keyserver-options auto-key-retrieve --verify archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre></p>
 
     {% cache 600 download-mirrors %}
     <div id="download-mirrors">


### PR DESCRIPTION
Link to *sum.txt files on archlinux.org, just like with the GPG signatures, as the mirrors cannot be trusted.

Add the GnuPG verification command from https://wiki.archlinux.org/title/Installation_guide#Verify_signature. It would be better if we do not duplicate it in both archweb and the wiki.