### PR TITLE
When linking iso downloads, only use https mirrors

### DIFF
--- a/public/views.py
+++ b/public/views.py
@@ -57,7 +57,7 @@ def _mirror_urls():
     '''In order to ensure this is lazily evaluated since we can't do
     sorting at the database level, make it a callable.'''
     urls = MirrorUrl.objects.select_related('mirror').filter(
-            active=True, protocol__default=True,
+            active=True, protocol__protocol='https',
             mirror__public=True, mirror__active=True, mirror__isos=True)
     sort_by = attrgetter('country.name', 'mirror.name')
     return sorted(urls, key=sort_by)


### PR DESCRIPTION
This issue was raised in #archlinux-security, and I also think listing https only mirrors on archlinux.org/download/ is a good idea.

Or put differently, I don't think insecure http is relevant enough anymore to list them on the download page.