### PR TITLE
templates/public/download.html: replace "CD" with "DVD"

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -20,7 +20,7 @@
 
     <h3>Release Info</h3>
 
-    <p>The image can be burned to a CD, mounted as an ISO file,
+    <p>The image can be burned to a DVD, mounted as an ISO file,
     or be <a href="https://wiki.archlinux.org/title/USB_flash_installation_medium">directly written to a USB flash drive</a>.
     It is intended for new installations only; an existing Arch Linux system
     can always be updated with <code>pacman -Syu</code>.</p>


### PR DESCRIPTION
Starting with archlinux-2024.02.01-x86_64.iso, the ISO size will exceed the maximum CD size (900 MiB).
Adjust the text to say "DVD" instead.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/144

/cc @dvzrv 