### PR TITLE
template: changed signing key download command for sq >= 0.33

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -102,7 +102,7 @@
 
     <p>The release signing key can be downloaded with WKD:</p>
 
-    <p><code>sq wkd get {{ release.wkd_email }} -o release-key.pgp</code></p>
+    <p><code>sq network wkd fetch {{ release.wkd_email }} -o release-key.pgp</code></p>
 
     <p>With this key the signature can be verified like this:</p>
 


### PR DESCRIPTION
sequoia-sq 0.33 has changed the `sq wkd get` command with `sq network wkd fetch`