### PR TITLE
Update flaghelp.html with link to GitLab

### DIFF
--- a/templates/packages/flaghelp.html
+++ b/templates/packages/flaghelp.html
@@ -24,7 +24,8 @@
         with your additional text.</p>
 
         <p><strong>Note:</strong> Please do <em>not</em> use this facility if the
-        package is broken! Use the <a target="_blank" href="https://bugs.archlinux.org/"
-            title="Arch Linux Bugtracker">bugtracker</a> instead.</p>
+        package is broken! File an issue on the package's <a target="_blank" href="https://gitlab.archlinux.org/archlinux/packaging/packages"
+            title="Arch Linux GitLab packages group">GitLab repository</a> 
+        instead.</p>
     </body>
 </html>


### PR DESCRIPTION
Now that the bugtracker has been moved to GitLab, the flaghelp text should match.