### PR TITLE
releng/models.py: update bootstrap tarball extension

### DIFF
--- a/releng/models.py
+++ b/releng/models.py
@@ -47,7 +47,7 @@ class Release(models.Model):
         return "iso/%s/archlinux-%s-x86_64.iso" % (self.version, self.version)
 
     def tarball_url(self):
-        return "iso/%s/archlinux-bootstrap-%s-x86_64.tar.gz" % (self.version, self.version)
+        return "iso/%s/archlinux-bootstrap-%s-x86_64.tar.zst" % (self.version, self.version)
 
     def dir_url(self):
         return "iso/%s" % (self.version)


### PR DESCRIPTION
archiso v77 changed the bootstrap tarball compression from gzip to zstd. See https://gitlab.archlinux.org/archlinux/archiso/-/merge_requests/373

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/130

/cc @dvzrv