### PR TITLE
templates/public/download.html: fix mismatched closing tag

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -124,7 +124,7 @@
         </li>
     </ul>
 
-    <h5>Download verification</h4>
+    <h5>Download verification</h5>
 
     <p>Verify the BLAKE2b checksums as follows: <pre><code>$ b2sum -c b2sums.txt</code></pre></p>
 


### PR DESCRIPTION
Reported in https://bbs.archlinux.org/viewtopic.php?id=295151

Fixes: b018f09fcada5a3b71d9b91bacfd1ddee9af9952 ("templates/public/download.html: update checksum and signature list and verification")