### PR TITLE
templates/base.html: close meta tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <meta name="theme-color" content="#08C">
+    <meta name="theme-color" content="#08C" />
     <title>{% block title %}Arch Linux{% endblock %}</title>
     <link rel="stylesheet" type="text/css" href="{% static "archweb.css" %}" media="screen" />
     <link rel="icon" type="image/png" href="{% static "favicon.png" %}" />


### PR DESCRIPTION
`meta` is a self-closing tag.