### PR TITLE
templates/public/download.html: fix HTML

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -126,18 +126,19 @@
 
     <h5>Download verification</h5>
 
-    <p>Verify the BLAKE2b checksums as follows: <pre><code>$ b2sum -c b2sums.txt</code></pre></p>
+    Verify the BLAKE2b checksums as follows:
+    <pre><code>$ b2sum -c b2sums.txt</code></pre>
 
-    <p>To verify the PGP signature using Sequoia, first download the release signing key from WKD:<br/>
+    To verify the PGP signature using Sequoia, first download the release signing key from WKD:
     <pre><code>$ sq network wkd fetch {{ release.wkd_email }} -o release-key.pgp</code></pre>
 
     With this signing key, verify the signature:
-    <pre><code>$ sq verify --signer-file release-key.pgp --detached archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre></p>
+    <pre><code>$ sq verify --signer-file release-key.pgp --detached archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre>
 
-    <p>Alternatively, using GnuPG, download the signing key from WKD:
+    Alternatively, using GnuPG, download the signing key from WKD:
     <pre><code>$ gpg --auto-key-locate clear,wkd -v --locate-external-key {{ release.wkd_email }}</code></pre>
     Verify the signature:
-    <pre><code>$ gpg --keyserver-options auto-key-retrieve --verify archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre></p>
+    <pre><code>$ gpg --keyserver-options auto-key-retrieve --verify archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre>
 
     {% cache 600 download-mirrors %}
     <div id="download-mirrors">

--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -117,11 +117,11 @@
                 <li><a href="https://archlinux.org/{{ release.tarball_url }}.sig"
                     title="Bootstrap tarball PGP signature">PGP signature</a></li>
             </ul>
-            {% if release.sha256_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha256sums.txt">sha256sums.txt</a></li>{% endif %}
-            {% if release.b2_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/b2sums.txt">b2sums.txt</a></li>{% endif %}
-            {% if release.sha1_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha1sums.txt">sha1sums.txt</a></li>{% endif %}
-            {% if release.md5_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/md5sums.txt">md5sums.txt</a></li>{% endif %}
         </li>
+        {% if release.sha256_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha256sums.txt">sha256sums.txt</a></li>{% endif %}
+        {% if release.b2_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/b2sums.txt">b2sums.txt</a></li>{% endif %}
+        {% if release.sha1_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/sha1sums.txt">sha1sums.txt</a></li>{% endif %}
+        {% if release.md5_sum %}<li><a href="https://archlinux.org/{{ release.dir_url }}/md5sums.txt">md5sums.txt</a></li>{% endif %}
     </ul>
 
     <h5>Download verification</h5>


### PR DESCRIPTION
# templates/public/download.html: fix list

Fix list items so that the closing li tag is properly recognized.

Fixes: b018f09fcada5a3b71d9b91bacfd1ddee9af9952 ("templates/public/download.html: update checksum and signature list and verification")

# templates/public/download.html: do not place pre tags inside p tags

The `<p>` element cannot contain `<pre>` elements.

Fixes: b018f09fcada5a3b71d9b91bacfd1ddee9af9952 ("templates/public/download.html: update checksum and signature list and verification")
