### PR TITLE
docs: fix the badge of the build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Archweb README
 
-[![Build Status](https://github.com/archlinux/archweb/workflows/Github-Actions/badge.svg)](https://github.com/archlinux/archweb/actions)
+[![Build Status](https://github.com/archlinux/archweb/actions/workflows/main.yml/badge.svg)](https://github.com/archlinux/archweb/actions/workflows/main.yml)
 
 To get a pretty version of this document, run
 


### PR DESCRIPTION
Fix the badge of the build status, see: https://github.com/shink/archweb/blob/docs/fix-badge/README.md

before:

[![Build Status](https://github.com/archlinux/archweb/workflows/Github-Actions/badge.svg)](https://github.com/archlinux/archweb/actions)

after:

[![Build Status](https://github.com/archlinux/archweb/actions/workflows/main.yml/badge.svg)](https://github.com/archlinux/archweb/actions/workflows/main.yml)
