### PR TITLE
Update to Django 5

### DIFF
--- a/mirrors/views/mirrorlist.py
+++ b/mirrors/views/mirrorlist.py
@@ -39,15 +39,6 @@ class MirrorlistForm(forms.Form):
         code_list = [(code, countries.name(code)) for code in country_codes]
         return sorted(code_list, key=itemgetter(1))
 
-    def as_div(self):
-        "Returns this form rendered as HTML <divs>s."
-        return self._html_output(
-            normal_row=u'<div%(html_class_attr)s>%(label)s %(field)s%(help_text)s</div>',
-            error_row=u'%s',
-            row_ender='</div>',
-            help_text_html=u' <span class="helptext">%s</span>',
-            errors_on_separate_row=True)
-
 
 @csrf_exempt
 def generate_mirrorlist(request):

--- a/planet/tests/test_command.py
+++ b/planet/tests/test_command.py
@@ -15,8 +15,10 @@ def command():
 
 @pytest.fixture
 def feed(db):
-    return Feed(title='test', website='http://archlinux.org',
+    feed = Feed.objects.create(title='test', website='http://archlinux.org',
                 website_rss='http://archlinux.org/feed.rss')
+    yield feed
+    feed.delete()
 
 
 class MockParse:

--- a/releng/migrations/0001_squashed_0005_auto_20180616_0947.py
+++ b/releng/migrations/0001_squashed_0005_auto_20180616_0947.py
@@ -6,7 +6,6 @@ import datetime
 
 import django.db.models.deletion
 from django.db import migrations, models
-from django.utils.timezone import utc
 
 
 # Functions from the following migrations need manual copying.
@@ -145,7 +144,7 @@ class Migration(migrations.Migration):
                 ('available', models.BooleanField(default=True)),
                 ('info', models.TextField(blank=True, verbose_name='Public information')),
                 ('torrent_data', models.TextField(blank=True, help_text='base64-encoded torrent file')),
-                ('last_modified', models.DateTimeField(default=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=utc), editable=False)),
+                ('last_modified', models.DateTimeField(default=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), editable=False)),
             ],
             options={
                 'ordering': ('-release_date', '-version'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/fredj/cssmin.git@master#egg=cssmin
-Django==4.2.11
+Django==5.0.6
 IPy==1.1
 Markdown==3.3.7
 bencode.py==4.0.0


### PR DESCRIPTION
Issues:

* The undocumented BaseForm._html_output() method is removed.
* Model instances passed to related filters must be saved.