### PR TITLE
devel: logout is a POST only action since Django 5.0

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -1197,3 +1197,24 @@ ul.signoff-list {
 .pgp-key-ids {
     display: inline-block;
 }
+
+.logout-form {
+    display: inline-block;
+
+    /* style input as a normal anchor */
+    input {
+      background: none!important;
+      border: none;
+      padding: 0!important;
+      /*optional*/
+      font-family: arial, sans-serif;
+      font-size: 0.9em;
+      /*input has OS specific font-family*/
+      color: #07b;
+    }
+
+    input:hover {
+        text-decoration: underline;
+        cursor: pointer;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,7 +55,11 @@
                     {% if user|in_groups:'Developers:Package Maintainers:Support Staff' %}
                     <li><a href="/devel/tier0mirror/" title="Your Tier 0 Mirror information">Tier0 mirror</a></li>
                     {% endif %}
-                    <li><a href="/logout/" title="Logout of the developer interface">Logout</a></li>
+                    <li>
+                        <form class="logout-form" method="post" action="/logout/">{% csrf_token %}
+                            <input type="submit" title="Logout of the developer interface" value="Logout"/>
+                        </form>
+                    </li>
                 </ul>
             {% endif %}
         </div>


### PR DESCRIPTION
We can no longer logout with a GET and as folks probably don't want to depend on JavaScript for logging out, add a form and style the input as an anchor to make POST'ing work.

Closes: #511