### PR TITLE
Use ISO 8601 date format

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -41,9 +41,6 @@ SITE_ID = 1
 DATE_FORMAT = 'Y-m-d'
 DATETIME_FORMAT = 'Y-m-d H:i'
 
-# Disable so our own DATE_FORMAT/DATETIME_FORMAT is used.
-USE_L10N = False
-
 # Login URL configuration
 LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/'

--- a/templates/devel/admin_log.html
+++ b/templates/devel/admin_log.html
@@ -30,7 +30,7 @@
     <tbody>
         {% for entry in admin_log %}
         <tr>
-            <th scope="row">{{ entry.action_time|date:"DATETIME_FORMAT" }}</th>
+            <th scope="row">{{ entry.action_time|date:"Y-m-d H:i" }}</th>
             {% if log_user %}
             <td>{{ entry.user.username }}{% if entry.user.get_full_name %} ({{ entry.user.get_full_name }}){% endif %}</td>
             {% else %}

--- a/templates/packages/package_details.html
+++ b/templates/packages/package_details.html
@@ -182,19 +182,19 @@
             {% else %}{{ pkg.packager_str }}{% endif %}{% endwith %}</td>
         </tr><tr>
             <th>Build Date:</th>
-            <td>{{ pkg.build_date|date:"DATETIME_FORMAT" }} UTC</td>
+            <td>{{ pkg.build_date|date:"Y-m-d H:i" }} UTC</td>
         </tr>{% if pkg.signature %}<tr>
             <th>Signed By:</th>
             <td>{% with signer=pkg.signer %}{% if signer %}{% pgp_key_link pkg.signature.key_id signer.get_full_name|safe %}{% else %}Unknown ({% pgp_key_link pkg.signature.key_id|safe %}){% endif %}{% endwith %}</td>
         </tr><tr>
             <th>Signature Date:</th>
-            <td>{{ pkg.signature.creation_time|date:"DATETIME_FORMAT" }} UTC</td>
+            <td>{{ pkg.signature.creation_time|date:"Y-m-d H:i" }} UTC</td>
         </tr>{% else %}<tr>
             <th>Signed By:</th>
             <td>Unsigned</td>
         </tr>{% endif %}<tr>
             <th>Last Updated:</th>
-            <td>{{ pkg.last_update|date:"DATETIME_FORMAT" }} UTC{% if pkg.is_recent %} <span class="recent" title="Your mirror may not yet have this package version">({{ pkg.last_update|naturaltime }})</span>{% endif %}</td>
+            <td>{{ pkg.last_update|date:"Y-m-d H:i" }} UTC{% if pkg.is_recent %} <span class="recent" title="Your mirror may not yet have this package version">({{ pkg.last_update|naturaltime }})</span>{% endif %}</td>
         </tr>
         {% if user.is_authenticated %}<tr>
             <th>Reproducible Status:</th>

--- a/templates/releng/release_detail.html
+++ b/templates/releng/release_detail.html
@@ -38,7 +38,7 @@
 
     <ul>
         <li><strong>Comment:</strong> {{ torrent.comment }}</li>
-        <li><strong>Creation Date:</strong> {{ torrent.creation_date|date:"DATETIME_FORMAT" }} UTC</li>
+        <li><strong>Creation Date:</strong> {{ torrent.creation_date|date:"Y-m-d H:i" }} UTC</li>
         <li><strong>Created By:</strong> {{ torrent.created_by }}</li>
         <li><strong>Announce URL:</strong> {{ torrent.announce }}</li>
         <li><strong>File Name:</strong> {{ torrent.file_name }}</li>


### PR DESCRIPTION
Explicitly specify the ISO 8601 format `Y-m-d H:i` in the date template.

Django 5.0.5 removed the `USE_L10N` setting making the locale-specific formats override `DATE_FORMAT` and `DATETIME_FORMAT`. See https://forum.djangoproject.com/t/datetime-format/30811/10 for details.

Fixes https://github.com/archlinux/archweb/issues/520