### PR TITLE
Improve the "zebra" style of dynamic tables where rows can be dynamically hidden

### DIFF
--- a/sitestatic/archweb.css
+++ b/sitestatic/archweb.css
@@ -754,6 +754,10 @@ table.results {
         text-align: center;
     }
 
+    .results [hidden] {
+        display: none;
+    }
+
 /* pkglist: layout */
 #pkglist-about {
     margin-top: 1.5em;
@@ -1056,12 +1060,12 @@ table td.country {
     background: #ffd;
 }
 
-.results tr:nth-child(even),
+.results tr:nth-child(even of :not([hidden])),
 #article-list tr:nth-child(even) {
     background: #e4eeff;
 }
 
-.results tr:nth-child(odd),
+.results tr:nth-child(odd of :not([hidden])),
 #article-list tr:nth-child(odd) {
     background: #fff;
 }

--- a/sitestatic/archweb.js
+++ b/sitestatic/archweb.js
@@ -212,8 +212,14 @@ function filter_pkgs_list(filter_ele, tbody_ele) {
         rows = rows.has('.incomplete');
     }
     /* hide all rows, then show the set we care about */
-    all_rows.hide();
-    rows.show();
+    // note that we don't use .hide() from jQuery because it adds display:none
+    // which is very expensive to query in CSS ([style*="display: none"])
+    all_rows.each(function() {
+        $(this).attr('hidden', true);
+    });
+    rows.each(function() {
+        $(this).removeAttr('hidden');
+    });
     $('#filter-count').text(rows.length);
     /* make sure we update the odd/even styling from sorting */
     $('.results').trigger('applyWidgets', [false]);
@@ -330,8 +336,14 @@ function filter_signoffs() {
         rows = rows.has('td.signoff-no');
     }
     /* hide all rows, then show the set we care about */
-    all_rows.hide();
-    rows.show();
+    // note that we don't use .hide() from jQuery because it adds display:none
+    // which is very expensive to query in CSS ([style*="display: none"])
+    all_rows.each(function() {
+        $(this).attr('hidden', true);
+    });
+    rows.each(function() {
+        $(this).removeAttr('hidden');
+    });
     $('#filter-count').text(rows.length);
     /* make sure we update the odd/even styling from sorting */
     $('.results').trigger('applyWidgets', [false]);


### PR DESCRIPTION
Currently, dynamic tables on archweb may look like this (a todo list with "Only Incomplete" checked; screenshot from a testing instance):

![screenshot-2024-12-07@19:21:19](https://github.com/user-attachments/assets/0aa831b8-f692-46ec-86b9-22fb9ac17cb6)

After this commit, it looks like a :zebra: again :smile: 

![screenshot-2024-12-07@19:20:25](https://github.com/user-attachments/assets/7bfbbf29-dc75-4289-84bb-f60a7c571b9e)
