### PR TITLE
Add `rel=me` to staff members' own website links

### DIFF
--- a/templates/public/developer_list.html
+++ b/templates/public/developer_list.html
@@ -47,7 +47,7 @@
                 </tr><tr>
                     <th>Website:</th>
                     <td>{% if prof.website %}<a itemprop="url" href="{{ prof.website }}"
-                            title="Visit the website for {{ dev.get_full_name }}">
+                            title="Visit the website for {{ dev.get_full_name }}" rel="me">
                             {{ prof.website }}</a>{% endif %}</td>
                 </tr><tr>
                     <th>Occupation:</th>


### PR DESCRIPTION
The `rel=me` is used to indicate [profile equivalence][0] and is used by [Mastodon's Link Verification][1]. If a staff member puts a link to their Fediverse account in the "website" field and cross-links the staff page on their Fediverse account (the link may include `#username` anchor) then the software will display the link as "green" thus giving others an indication that this person is indeed an Arch staff member.

Note that I have *not* ran Archweb locally with this change :sweat_smile: 

I mock-up of how it should look like:

1. Adding the link to Mastodon on archweb:

![2025-02-17-13-56-16](https://github.com/user-attachments/assets/30c2171f-45d5-4528-84b7-587cadeef403)

2. Adding a back-link to the staff site on Mastodon:

![2025-02-17-13-56-24](https://github.com/user-attachments/assets/dc3b3250-5cc7-4d7c-96f9-d854b2930eaa)

3. There's no step 3. It just works and is green and green == good.

CC: @anthraxx with whom I've discussed that at FOSDEM.

[0]: https://microformats.org/wiki/rel-me
[1]: https://docs.joinmastodon.org/user/profile/#verification