### PR TITLE
Add the automated install & run method for the WSL image to the Download page

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -95,7 +95,11 @@
 
     <h3>WSL images</h3>
 
-    <p>Official WSL images are available for download on <a href="https://geo.mirror.pkgbuild.com/wsl/latest">mirrors</a>, more information is available in the <a href="https://wiki.archlinux.org/title/Install_Arch_Linux_on_WSL">Wiki</a>.</p>
+    <p>The official WSL image can be installed with the following command (in a PowerShell prompt from a Windows system with WSL 2 installed):</p>
+    <code>wsl --install archlinux</code>
+
+    <p>It is also available for download on <a href="https://geo.mirror.pkgbuild.com/wsl/latest">mirrors</a>.</p>
+    <p>More information available in the <a href="https://wiki.archlinux.org/title/Install_Arch_Linux_on_WSL">Wiki</a>.</p>
 
     <h3 id="http-downloads">HTTP Direct Downloads</h3>
 


### PR DESCRIPTION
This automated `wsl --install archlinux` method will only be functional after https://github.com/microsoft/WSL/pull/12818 is merged, so we should wait for that before merging & deploying this PR (I'll remove the draft status once okay).