### PR TITLE
public: Remove Vagrant images

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -77,13 +77,6 @@
             title="Arch Linux Netboot">Arch Linux Netboot</a></li>
     </ul>
 
-    <h3>Vagrant images</h3>
-
-    <p>Vagrant images for libvirt and virtualbox are available on the <a href="https://app.vagrantup.com/archlinux/boxes/archlinux">Vagrant Cloud</a>. You can bootstrap the image with the following commands:</p>
-    <code>vagrant init archlinux/archlinux</code>
-    <br/>
-    <code>vagrant up</code>
-
     <h3>Docker image</h3>
 
     <p>The official Docker image is available on <a href="https://hub.docker.com/_/archlinux/">Docker Hub</a>. You can run the image with the following command:</p>


### PR DESCRIPTION
We are no longer releasing Vagrant images[1].

[1] https://gitlab.archlinux.org/archlinux/arch-boxes/-/commit/3f7b895725e9fa2f31436234a3b4a4e7f477f69d