### PR TITLE
Fix typo on "Multilib Differences to Main Packages" page

### DIFF
--- a/templates/packages/differences.html
+++ b/templates/packages/differences.html
@@ -16,7 +16,7 @@
                 <th>Multilib Version</th>
                 <th>x86_64 Version</th>
                 <th>x86_64 Name</th>
-                <th>x864_ Repo</th>
+                <th>x86_64 Repo</th>
                 <th>Multilib Last Updated</th>
                 <th>x86_64 Last Updated</th>
             </tr>


### PR DESCRIPTION
"x864_" is a typo of "x86_64".

https://archlinux.org/packages/differences