### PR TITLE
templates/public/download.html: remove gpg keyserver-options

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -141,7 +141,7 @@
     Alternatively, using GnuPG, download the signing key from WKD:
     <pre><code>$ gpg --auto-key-locate clear,wkd -v --locate-external-key {{ release.wkd_email }}</code></pre>
     Verify the signature:
-    <pre><code>$ gpg --keyserver-options auto-key-retrieve --verify archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre>
+    <pre><code>$ gpg --verify archlinux-{{ release.version }}-x86_64.iso.sig archlinux-{{ release.version }}-x86_64.iso</code></pre>
 
     {% cache 600 download-mirrors %}
     <div id="download-mirrors">


### PR DESCRIPTION
The public key is retrieved via WKD in the previous command, so there is no reason to contact any keyservers.