### PR TITLE
Add link to new Dev Blog in Development section

### DIFF
--- a/templates/public/index.html
+++ b/templates/public/index.html
@@ -153,6 +153,7 @@
     <ul>
         <li><a href="https://wiki.archlinux.org/title/Getting_involved"
             title="Getting involved">Getting involved</a></li>
+        <li><a href="https://devblog.archlinux.page" title="Dev Blog">Dev Blog</a></li>
         <li><a href="https://gitlab.archlinux.org/archlinux/"
             title="Official Arch projects (git)">Projects in Git</a></li>
         <li><a href="https://wiki.archlinux.org/title/DeveloperWiki"


### PR DESCRIPTION
https://gitlab.archlinux.org/archlinux/devblog/ gets published to https://devblog.archlinux.page/ and we probably want to link this.