### PR TITLE
Fix format string for package links in todo lists

### DIFF
--- a/todolists/templatetags/todolists.py
+++ b/todolists/templatetags/todolists.py
@@ -13,7 +13,7 @@ def todopkg_details_link(todopkg):
     pkg = todopkg.pkg
     if not pkg:
         return todopkg.pkgname
-    link = '<a href={url}s" title="View package details for {pkgname}">{pkgname}</a>'
+    link = '<a href="{url}" title="View package details for {pkgname}">{pkgname}</a>'
     url = pkg_absolute_url(todopkg.repo, todopkg.arch, pkg.pkgname)
     return format_html(link, url=url, pkgname=pkg.pkgname)
 


### PR DESCRIPTION
Fixes 0cf24055d5181fa516c8182a29f1deef7652b725

Fixes https://github.com/archlinux/archweb/issues/582