### PR TITLE
main: render package maintainers pgp keys correctly

### DIFF
--- a/main/templatetags/pgp.py
+++ b/main/templatetags/pgp.py
@@ -59,7 +59,7 @@ def pgp_key_link(key_id, link_text=None):
     return format_html('<a href="{url}" title="PGP key search for {key}">{content}</a>',
                        url=url,
                        key=format_key(key_id),
-                       content=link_text)
+                       content=mark_safe(link_text))
 
 
 @register.simple_tag


### PR DESCRIPTION
We need to allow html to be passed into format_html.