### PR TITLE
Fix URL formatting for PGP key lookup

### DIFF
--- a/main/templatetags/pgp.py
+++ b/main/templatetags/pgp.py
@@ -51,9 +51,9 @@ def pgp_key_link(key_id, link_text=None):
         return format_key(key_id)
     pgp_server_secure = getattr(settings, 'PGP_SERVER_SECURE', False)
     scheme = 'https' if pgp_server_secure else 'http'
-    url = '%s://%s/pks/lookup?op=vindex&amp;fingerprint=on&amp;exact=on&amp;search=0x%s' % (scheme,
-                                                                                            pgp_server,
-                                                                                            key_id)
+    url = '%s://%s/pks/lookup?op=vindex&fingerprint=on&exact=on&search=0x%s' % (scheme,
+                                                                                pgp_server,
+                                                                                key_id)
     if link_text is None:
         link_text = '0x%s' % key_id[-8:]
     return format_html('<a href="{url}" title="PGP key search for {key}">{content}</a>',


### PR DESCRIPTION
The URL currently returns a "Bad Request" error without the change here.