### PR TITLE
Switch the WSL image download link to the new Fastly CDN mirror

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -91,7 +91,7 @@
     <p>The official WSL image can be installed with the following command (in a PowerShell prompt from a Windows system with WSL 2 installed):</p>
     <code>wsl --install archlinux</code>
 
-    <p>It is also available for download on <a href="https://geo.mirror.pkgbuild.com/wsl/latest">mirrors</a>.</p>
+    <p>It is also available for download on <a href="https://fastly.mirror.pkgbuild.com/wsl/latest">mirrors</a>.</p>
     <p>More information available in the <a href="https://wiki.archlinux.org/title/Install_Arch_Linux_on_WSL">Wiki</a>.</p>
 
     <h3 id="http-downloads">HTTP Direct Downloads</h3>


### PR DESCRIPTION
We are now using / promoting the new Fastly CDN mirror as the default one for releng projects (see https://gitlab.archlinux.org/archlinux/archlinux-wsl/-/issues/17)