### PR TITLE
Correct number of AUR build scripts in about.html

### DIFF
--- a/templates/public/about.html
+++ b/templates/public/about.html
@@ -28,7 +28,7 @@ The minimal Arch base package set resides in the streamlined [core] repository.
 In addition, the official [extra], [extra-testing], and [core-testing] repositories
 provide several thousand high-quality packages to meet your software demands.
 Arch also offers the Arch Linux User Repository (AUR), which contains more than
-49,000 build scripts, for compiling installable packages from source using the
+96,000 build scripts, for compiling installable packages from source using the
 Arch Linux makepkg application.
 </p>
 <p>

--- a/templates/public/about.html
+++ b/templates/public/about.html
@@ -28,7 +28,7 @@ The minimal Arch base package set resides in the streamlined [core] repository.
 In addition, the official [extra], [extra-testing], and [core-testing] repositories
 provide several thousand high-quality packages to meet your software demands.
 Arch also offers the Arch Linux User Repository (AUR), which contains more than
-96,000 build scripts, for compiling installable packages from source using the
+100,000 build scripts, for compiling installable packages from source using the
 Arch Linux makepkg application.
 </p>
 <p>


### PR DESCRIPTION
Updated the number of build scripts in the AUR from 49,000 to 100,000.

This is not a big issue but necessary to be competitive IMHO.