### PR TITLE
Add missing fields for releng release json api

### DIFF
--- a/releng/fixtures/release.json
+++ b/releng/fixtures/release.json
@@ -6,6 +6,7 @@
             "info": "public information",
             "kernel_version": "4.12",
             "last_modified": "2017-06-11T16:53:53.723Z",
+            "pgp_key": "0x3E80CA1A8B89F69CBA57D98A76A5EF9054449A5C",
             "md5_sum": "f029d6004e63464b1b26c62058c4e37e",
             "release_date": "2017-06-11",
             "wkd_email": "pierre@archlinux.de",

--- a/releng/tests/conftest.py
+++ b/releng/tests/conftest.py
@@ -9,12 +9,20 @@ from releng.models import Release
 VERSION = '1.0'
 KERNEL_VERSION = '4.18'
 
+# Sample signing identity; same values as releng/fixtures/release.json (PGPKeyField stores 40 hex digits).
+PGP_KEY_FINGERPRINT = '3E80CA1A8B89F69CBA57D98A76A5EF9054449A5C'
+WKD_EMAIL = 'pierre@archlinux.de'
+
 
 @pytest.fixture
 def release(db):
-    release = Release.objects.create(release_date=datetime.now(),
-                                     version=VERSION,
-                                     kernel_version=KERNEL_VERSION)
+    release = Release.objects.create(
+        release_date=datetime.now(),
+        version=VERSION,
+        kernel_version=KERNEL_VERSION,
+        pgp_key=PGP_KEY_FINGERPRINT,
+        wkd_email=WKD_EMAIL,
+    )
     yield release
     release.delete()
 

--- a/releng/tests/test_views.py
+++ b/releng/tests/test_views.py
@@ -7,12 +7,17 @@ def test_release_json(client, release, torrent_data):
     assert data['version'] == 1
     release_data = data['releases'][0]
     assert release_data['version'] == version
+    assert release_data['pgp_fingerprint'] == release.pgp_key
+    assert release_data['wkd_email'] == release.wkd_email
 
     # Test with torrent data
     release.torrent_data = torrent_data
     release.save()
     response = client.get('/releng/releases/json/')
     assert response.status_code == 200
+    release_data = response.json()['releases'][0]
+    assert release_data['pgp_fingerprint'] == release.pgp_key
+    assert release_data['wkd_email'] == release.wkd_email
 
 
 def test_json(db, client):
@@ -21,6 +26,23 @@ def test_json(db, client):
 
     data = response.json()
     assert data['releases'] == []
+
+
+def test_release_json_null_pgp_fingerprint_and_wkd_email(client, db):
+    from datetime import datetime
+
+    from releng.models import Release
+
+    Release.objects.create(
+        release_date=datetime.now(),
+        version='9.9.9',
+        kernel_version='1.0',
+    )
+    response = client.get('/releng/releases/json/')
+    assert response.status_code == 200
+    release_data = response.json()['releases'][0]
+    assert release_data['pgp_fingerprint'] is None
+    assert release_data['wkd_email'] is None
 
 
 def test_netboot_page(db, client):

--- a/releng/views.py
+++ b/releng/views.py
@@ -45,7 +45,7 @@ class ReleaseJSONEncoder(DjangoJSONEncoder):
         if isinstance(obj, Release):
             data = {attr: getattr(obj, attr) or None
                     for attr in self.release_attributes}
-            data['pgp_fingerprint'] = obj.pgp_key or None
+            data['pgp_fingerprint'] = obj.pgp_key
             data['available'] = obj.available
             data['iso_url'] = '/' + obj.iso_url()
             data['magnet_uri'] = obj.magnet_uri()

--- a/releng/views.py
+++ b/releng/views.py
@@ -38,12 +38,14 @@ def release_torrent(request, version):
 
 class ReleaseJSONEncoder(DjangoJSONEncoder):
     release_attributes = ('release_date', 'version', 'kernel_version',
-                          'created', 'md5_sum', 'sha1_sum', 'sha256_sum', 'b2_sum')
+                          'created', 'md5_sum', 'sha1_sum', 'sha256_sum', 'b2_sum',
+                          'wkd_email')
 
     def default(self, obj):
         if isinstance(obj, Release):
             data = {attr: getattr(obj, attr) or None
                     for attr in self.release_attributes}
+            data['pgp_fingerprint'] = obj.pgp_key or None
             data['available'] = obj.available
             data['iso_url'] = '/' + obj.iso_url()
             data['magnet_uri'] = obj.magnet_uri()


### PR DESCRIPTION
## This MR:
- adds "pgp_fingerprint" and "wkd_email" to /releng/releases/json
- extends the fixtures with a pgp_key

Response with new fixture:

```json
{
    "version": 1,
    "releases": [
        {
            "release_date": "2017-06-11",
            "version": "2022.06.01",
            "kernel_version": "4.12",
            "created": "2017-06-07T19:36:49.569Z",
            "md5_sum": "f029d6004e63464b1b26c62058c4e37e",
            "sha1_sum": "2c2c8ce676e891ac354cf4a8bac3824a4aae0c90",
            "sha256_sum": "1f2ecf3eec6013c49224445c469069b269dae47efb8e161bc6334c6611c3a1ec",
            "b2_sum": "8c9ffd1f8213247004e2439bdf5688db45208a0135013c100837227cc7a38d2616888cb16bb69204def929083e749c13903bad68f47f2924204d6abd58d816b3",
            "wkd_email": "pierre@archlinux.de",
            "pgp_fingerprint": "3E80CA1A8B89F69CBA57D98A76A5EF9054449A5C",
            "available": true,
            "iso_url": "/iso/2022.06.01/archlinux-2022.06.01-x86_64.iso",
            "magnet_uri": "magnet:?dn=archlinux-2022.06.01-x86_64.iso",
            "torrent_url": "/releng/releases/2022.06.01/torrent/",
            "info": "<p>public information</p>",
            "torrent": null
        }
    ],
    "latest_version": "2022.06.01"
}
```