### PR TITLE
Fix duplicate maintainers on package pages (#427)

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -177,7 +177,8 @@ class Package(models.Model):
         if self._maintainers is None:
             self._maintainers = User.objects.filter(
                 package_relations__pkgbase=self.pkgbase,
-                package_relations__type=PackageRelation.MAINTAINER)
+                package_relations__type=PackageRelation.MAINTAINER,
+            ).distinct()
         return self._maintainers
 
     @maintainers.setter


### PR DESCRIPTION
Fixes: #427 

This pull requests appends .distinct() to the User queryset in Package.maintainers so each user is returned at most once, regardless of duplicate relation rows.