### PR TITLE
Add pkgbases export endpoint to developer reports

### DIFF
--- a/devel/tests/test_reports.py
+++ b/devel/tests/test_reports.py
@@ -58,3 +58,18 @@ class DeveloperReport(TransactionTestCase):
     def test_reports_signature_time(self):
         response = self.client.get('/devel/reports/signature-time', follow=True)
         self.assertEqual(response.status_code, 200)
+
+    def test_reports_pkgbases(self):
+        response = self.client.get('/devel/reports/old/pkgbases/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/plain')
+
+    def test_reports_pkgbases_with_username(self):
+        response = self.client.get(
+            f'/devel/reports/uncompressed-man/{self.user.username}/pkgbases/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/plain')
+
+    def test_reports_pkgbases_invalid_report(self):
+        response = self.client.get('/devel/reports/nonexistent/pkgbases/')
+        self.assertEqual(response.status_code, 404)

--- a/devel/urls.py
+++ b/devel/urls.py
@@ -12,6 +12,9 @@ urlpatterns = [
     path('stats/', views.stats, name='devel-stats'),
     path('newuser/', views.new_user_form),
     path('profile/', views.change_profile),
+    re_path(r'^reports/(?P<report_name>.*)/(?P<username>.*)/pkgbases/$',
+            views.report_pkgbases),
+    re_path(r'^reports/(?P<report_name>.*)/pkgbases/$', views.report_pkgbases),
     re_path(r'^reports/(?P<report_name>.*)/(?P<username>.*)/$', views.report),
     re_path(r'^reports/(?P<report_name>.*)/$', views.report),
 ]

--- a/devel/views.py
+++ b/devel/views.py
@@ -266,6 +266,22 @@ def change_profile(request):
 
 
 @login_required
+def report_pkgbases(request, report_name: str, username: str | None = None) -> HttpResponse:
+    report = {report.slug: report for report in available_reports()}.get(report_name, None)
+    if report is None:
+        raise Http404
+
+    packages = Package.objects.normal()
+    if report.slug in ('uncompressed-man', 'uncompressed-info'):
+        packages = report.packages(packages, username)
+    else:
+        packages = report.packages(packages)
+
+    pkgbases = sorted({pkg.pkgbase for pkg in packages})
+    return HttpResponse('\n'.join(pkgbases), content_type='text/plain')
+
+
+@login_required
 def report(request, report_name, username=None):
     available = {report.slug: report for report in available_reports()}
     report = available.get(report_name, None)

--- a/devel/views.py
+++ b/devel/views.py
@@ -265,6 +265,27 @@ def change_profile(request):
                    'profile_form': profile_form})
 
 
+def get_report_packages(report, username):
+    packages = Package.objects.normal()
+    if report.slug in ('uncompressed-man', 'uncompressed-info'):
+        packages = report.packages(packages, username)
+    else:
+        packages = report.packages(packages)
+
+    return packages
+
+
+@login_required
+def report_pkgbases(request, report_name: str, username: str | None = None) -> HttpResponse:
+    report = {report.slug: report for report in available_reports()}.get(report_name, None)
+    if report is None:
+        raise Http404
+
+    packages = get_report_packages(report, username)
+    pkgbases = sorted({pkg.pkgbase for pkg in packages})
+    return HttpResponse('\n'.join(pkgbases), content_type='text/plain')
+
+
 @login_required
 def report(request, report_name, username=None):
     available = {report.slug: report for report in available_reports()}
@@ -283,11 +304,7 @@ def report(request, report_name, username=None):
     maints = User.objects.filter(id__in=PackageRelation.objects.filter(
         type=PackageRelation.MAINTAINER).values('user'))
 
-    if report.slug == 'uncompressed-man' or report.slug == 'uncompressed-info':
-        packages = report.packages(packages, username)
-    else:
-        packages = report.packages(packages)
-
+    packages = get_report_packages(report, username)
     arches = {pkg.arch for pkg in packages}
     repos = {pkg.repo for pkg in packages}
     context = {

--- a/templates/devel/packages.html
+++ b/templates/devel/packages.html
@@ -13,6 +13,9 @@
     {% if maintainer %}This report only includes packages maintained by
     {{ maintainer.get_full_name }} ({{ maintainer.username }}).{% endif %}
     </p>
+    <p>
+    <a href="pkgbases">Link to list of pkgbases values</a>
+    </p>
 
     <div class="box filter-criteria">
         <h3>Filter Packages</h3>


### PR DESCRIPTION
This PR adds pkgbases export endpoint to developer reports, mirroring the existing todolist endpoint.

<img width="1831" height="916" alt="screen" src="https://github.com/user-attachments/assets/667eba04-b3f8-4c6f-9c6a-b79eb35f04eb" />

This solves #659.