### PR TITLE
ci/cd: prevent multiple workflows for the same code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Github-Actions
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
This change prevents multiple runs for the same code, which can happen if someone pushes changes quick enough after a previous push.

See also: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency