### PR TITLE
Compress flagged packages on the dashboard

### DIFF
--- a/devel/views.py
+++ b/devel/views.py
@@ -25,6 +25,7 @@ from django.utils.timezone import now
 from django.views.decorators.cache import cache_control, never_cache
 
 from main.models import Arch, Package, Repo
+from main.utils import groupby_preserve_order
 from news.models import News
 from packages.models import FlagRequest, PackageRelation, Signoff
 from packages.utils import get_signoff_groups
@@ -46,8 +47,13 @@ def index(request):
         inner_q = PackageRelation.objects.none()
     inner_q = inner_q.values('pkgbase')
 
-    flagged = Package.objects.normal().filter(
+    # select all flagged packages by pkgname
+    flagged_all = Package.objects.normal().filter(
         flag_date__isnull=False, pkgbase__in=inner_q).order_by('pkgname')
+
+    # group flagged packages by pkgbase
+    same_pkgbase_key = lambda x: (x.repo.name, x.arch.name, x.pkgbase)
+    flagged = groupby_preserve_order(flagged_all, same_pkgbase_key)
 
     todopkgs = TodolistPackage.objects.select_related(
         'todolist', 'pkg', 'arch', 'repo').exclude(

--- a/templates/devel/index.html
+++ b/templates/devel/index.html
@@ -26,19 +26,26 @@
             </tr>
         </thead>
         <tbody>
-            {% for pkg in flagged %}
-                <tr>
-                    <td>{% pkg_details_link pkg %}</td>
-                    <td>{{ pkg.full_version }}</td>
-                    <td>{% with pkg.in_testing as tp %}{% if tp %}
-                        <a href="{{ tp.get_absolute_url }}"
-                            title="Testing package details for {{ tp.pkgname }}">{{ tp.full_version }}</a>
-                        {% endif %}{% endwith %}</td>
-                    <td>{{ pkg.repo.name }}</td>
-                    <td>{{ pkg.arch.name }}</td>
-                    <td>{{ pkg.flag_date|date:"Y-m-d" }}</td>
-                    <td>{{ pkg.last_update|date:"Y-m-d" }}</td>
-                </tr>
+            {% for splitpkg in flagged %}
+                {% with splitpkg|first as pkg %}
+                    <tr>
+                        <td>
+                            {% pkg_details_link splitpkg.0 %}
+                            {% if splitpkg|length > 1 %}
+                                ({{ splitpkg|length }} split packages)
+                            {% endif %}
+                        </td>
+                        <td>{{ pkg.full_version }}</td>
+                        <td>{% with pkg.in_testing as tp %}{% if tp %}
+                            <a href="{{ tp.get_absolute_url }}"
+                                title="Testing package details for {{ tp.pkgname }}">{{ tp.full_version }}</a>
+                            {% endif %}{% endwith %}</td>
+                        <td>{{ pkg.repo.name }}</td>
+                        <td>{{ pkg.arch.name }}</td>
+                        <td>{{ pkg.flag_date|date:"Y-m-d" }}</td>
+                        <td>{{ pkg.last_update|date:"Y-m-d" }}</td>
+                    </tr>
+                {% endwith %}
             {% empty %}
                 <tr class="empty"><td colspan="7"><em>No flagged packages to display</em></td></tr>
             {% endfor %}


### PR DESCRIPTION
Out-of-date flagging and version bumping is related to pkgbase rather than pkgname, it does not make sense to duplicate the same information on multiple rows in the dashboard.

Before:

<img width="1228" height="645" alt="screenshot-2026-05-15@22-24-40" src="https://github.com/user-attachments/assets/b24d91c6-c513-4767-819f-727d63671c00" />


After:

<img width="1231" height="431" alt="screenshot-2026-05-15@22-24-03" src="https://github.com/user-attachments/assets/53ce408e-bd06-41e0-b3e3-26404a2563bf" />
