### PR TITLE
Add rsync mirror note to download page

### DIFF
--- a/templates/public/download.html
+++ b/templates/public/download.html
@@ -100,6 +100,8 @@
     downloaded via HTTP from the <a href="#download-mirrors">mirror sites listed below</a>. Please
     ensure the download image matches the checksum from the <code>sha256sums.txt</code> or <code>b2sums.txt</code> file linked below.</p>
 
+    <p>Many Arch Linux mirrors also support rsync.</p>
+
     <h4 id="checksums">Checksums and signatures</h4>
     <p>File integrity checksums and PGP signatures for the latest releases can be found below:</p>
 


### PR DESCRIPTION
## Summary

Add a short note mentioning rsync support on the download page.

## Changes

- Add a sentence informing users that some Arch Linux mirrors support rsync
- Place the note below the HTTP direct downloads section

## Verification

- Verified the new note renders correctly on the downloads page
- Confirmed formatting matches surrounding content