### PR TITLE
fix(#586): flagging a pkgver out of date no longer flags newer versions

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -373,6 +373,35 @@ class Package(models.Model):
             repo__staging=self.repo.staging,
             pkgbase=self.pkgbase).exclude(id=self.id)
 
+    def flag_peers(self, *, unflagged_only=False, flag_date=None):
+        """
+        Return packages marked out-of-date together with this one.
+
+        Includes split packages (same pkgbase) in repositories with matching
+        testing/staging flags whose version is not newer than this package, as
+        well as older pkgbase versions in those repositories.
+        """
+        qs = Package.objects.normal().filter(
+            pkgbase=self.pkgbase,
+            repo__testing=self.repo.testing,
+            repo__staging=self.repo.staging,
+        )
+        if unflagged_only:
+            qs = qs.filter(flag_date__isnull=True)
+        elif flag_date is not None:
+            qs = qs.filter(flag_date=flag_date)
+        qs = qs.order_by('pkgname', 'repo__name', 'arch__name')
+
+        alpm = AlpmAPI()
+        if alpm.available:
+            peer_ids = [
+                peer.id for peer in qs
+                if alpm.vercmp(peer.full_version, self.full_version) <= 0
+            ]
+            return Package.objects.normal().filter(id__in=peer_ids).order_by(
+                'pkgname', 'repo__name', 'arch__name')
+        return qs.filter(pkgver=self.pkgver, epoch=self.epoch)
+
     def flag_request(self):
         if self.flag_date is None:
             return None

--- a/packages/models.py
+++ b/packages/models.py
@@ -214,11 +214,24 @@ class FlagRequest(models.Model):
         return f'{self.pkgver}-{self.pkgrel}'
 
     def get_associated_packages(self):
-        return Package.objects.normal().filter(
+        packages = Package.objects.normal().filter(
             pkgbase=self.pkgbase,
             repo__testing=self.repo.testing,
-            repo__staging=self.repo.staging).order_by(
-            'pkgname', 'repo__name', 'arch__name')
+            repo__staging=self.repo.staging,
+        ).order_by('pkgname', 'repo__name', 'arch__name')
+        if self.pkgver == '' and self.pkgrel == '':
+            return packages
+
+        alpm = AlpmAPI()
+        if alpm.available:
+            ref = self.full_version
+            peer_ids = [
+                pkg.id for pkg in packages
+                if alpm.vercmp(pkg.full_version, ref) <= 0
+            ]
+            return Package.objects.normal().filter(id__in=peer_ids).order_by(
+                'pkgname', 'repo__name', 'arch__name')
+        return packages.filter(pkgver=self.pkgver, epoch=self.epoch)
 
     def __str__(self):
         return f'{self.pkgbase} from {self.who()} on {self.created}'

--- a/packages/tests/test_flag_packages.py
+++ b/packages/tests/test_flag_packages.py
@@ -1,3 +1,89 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from main.models import Arch, Package, Repo
+from packages.alpm import AlpmAPI
+
+alpm = AlpmAPI()
+
+
+@pytest.fixture
+def gnome_backgrounds_packages(db, arches, repos):
+    extra = Repo.objects.get(name__iexact='extra')
+    multilib = Repo.objects.get(name__iexact='multilib')
+    arch = Arch.objects.get(name='x86_64')
+    created = datetime.now(tz=timezone.utc)
+
+    def create(repo, pkgname, pkgver):
+        return Package.objects.create(
+            arch=arch,
+            repo=repo,
+            pkgname=pkgname,
+            pkgbase='gnome-backgrounds',
+            pkgver=pkgver,
+            pkgrel='1',
+            pkgdesc='test',
+            compressed_size=1,
+            installed_size=1,
+            last_update=created,
+            created=created,
+        )
+
+    return {
+        'older': create(extra, 'gnome-backgrounds', '48.2.1'),
+        'newer': create(multilib, 'gnome-backgrounds', '49.0'),
+        'split': create(extra, 'gnome-backgrounds-extra', '48.2.1'),
+    }
+
+
+def _flag_data():
+    return {
+        'website': '',
+        'email': 'nobody@archlinux.org',
+        'message': 'new upstream release',
+    }
+
+
+@pytest.mark.skipif(not alpm.available, reason="ALPM is unavailable")
+def test_flag_older_does_not_flag_newer(client, gnome_backgrounds_packages, mailoutbox):
+    older = gnome_backgrounds_packages['older']
+    newer = gnome_backgrounds_packages['newer']
+    split = gnome_backgrounds_packages['split']
+
+    response = client.post(
+        f'/packages/{older.repo.name.lower()}/{older.arch.name}/{older.pkgname}/flag/',
+        _flag_data(),
+        follow=True,
+    )
+    assert response.status_code == 200
+
+    older.refresh_from_db()
+    newer.refresh_from_db()
+    split.refresh_from_db()
+    assert older.flag_date is not None
+    assert split.flag_date is not None
+    assert newer.flag_date is None
+
+
+@pytest.mark.skipif(not alpm.available, reason="ALPM is unavailable")
+def test_flag_newer_flags_older(client, gnome_backgrounds_packages, mailoutbox):
+    older = gnome_backgrounds_packages['older']
+    newer = gnome_backgrounds_packages['newer']
+
+    response = client.post(
+        f'/packages/{newer.repo.name.lower()}/{newer.arch.name}/{newer.pkgname}/flag/',
+        _flag_data(),
+        follow=True,
+    )
+    assert response.status_code == 200
+
+    older.refresh_from_db()
+    newer.refresh_from_db()
+    assert older.flag_date is not None
+    assert newer.flag_date is not None
+
+
 def test_flag_package(client, package, mailoutbox):
     data = {
         'website': '',

--- a/packages/views/flag.py
+++ b/packages/views/flag.py
@@ -57,11 +57,7 @@ def flag(request, name, repo, arch):
         # already flagged. do nothing.
         return render(request, 'packages/flagged.html', {'pkg': pkg})
     # find all packages from (hopefully) the same PKGBUILD
-    pkgs = Package.objects.normal().filter(
-        pkgbase=pkg.pkgbase, flag_date__isnull=True,
-        repo__testing=pkg.repo.testing,
-        repo__staging=pkg.repo.staging).order_by(
-        'pkgname', 'repo__name', 'arch__name')
+    pkgs = pkg.flag_peers(unflagged_only=True)
 
     authenticated = request.user.is_authenticated
 
@@ -142,11 +138,7 @@ def flag(request, name, repo, arch):
 def flag_confirmed(request, name, repo, arch):
     pkg = get_object_or_404(Package,
                             pkgname=name, repo__name__iexact=repo, arch__name=arch)
-    pkgs = Package.objects.normal().filter(
-        pkgbase=pkg.pkgbase, flag_date=pkg.flag_date,
-        repo__testing=pkg.repo.testing,
-        repo__staging=pkg.repo.staging).order_by(
-        'pkgname', 'repo__name', 'arch__name')
+    pkgs = pkg.flag_peers(flag_date=pkg.flag_date)
 
     context = {'package': pkg, 'packages': pkgs}
 
@@ -166,10 +158,7 @@ def unflag(request, name, repo, arch):
 def unflag_all(request, name, repo, arch):
     pkg = get_object_or_404(Package.objects.normal(),
                             pkgname=name, repo__name__iexact=repo, arch__name=arch)
-    # find all packages from (hopefully) the same PKGBUILD
-    pkgs = Package.objects.filter(pkgbase=pkg.pkgbase,
-                                  repo__testing=pkg.repo.testing, repo__staging=pkg.repo.staging)
-    pkgs.update(flag_date=None)
+    pkg.flag_peers().update(flag_date=None)
     return redirect(pkg)
 
 # vim: set ts=4 sw=4 et:


### PR DESCRIPTION
This pull request:

- adds a version filter when flagging a package out of date: `alpm.vercmp(peer.full_version, self.full_version) <= 0`. This is the core fix for #586 
- refactors the core logic of flagging into `flag_peers()` which makes the code a bit more DRY
- adds a test for flagging packages behavior

Relates to: https://github.com/archlinux/archweb/issues/586