### PR TITLE
packages: Disable manual out of date flagging

### DIFF
--- a/packages/tests/test_flag_packages.py
+++ b/packages/tests/test_flag_packages.py
@@ -1,72 +1,10 @@
-def test_flag_package(client, package, mailoutbox):
-    data = {
-        'website': '',
-        'email': 'nobody@archlinux.org',
-        'message': 'new linux version',
-    }
-    response = client.post('/packages/core/x86_64/linux/flag/',
-                           data,
-                           follow=True)
-    assert response.status_code == 200
-    assert 'Package Flagged - linux' in response.content.decode()
-    assert len(mailoutbox) == 1
-    assert 'package [linux] marked out-of-date' in mailoutbox[0].subject
+from django.utils import timezone
 
-    # Flag again, should fail
-    response = client.post('/packages/core/x86_64/linux/flag/',
-                           data,
-                           follow=True)
-    assert response.status_code == 200
-    assert 'has already been flagged out-of-date.' in response.content.decode()
+from main.models import Package
 
 
-def test_flag_package_invalid(client, package, mailoutbox):
-    data = {
-        'website': '',
-        'email': 'nobody@archlinux.org',
-        'message': 'a',
-    }
-    response = client.post('/packages/core/x86_64/linux/flag/',
-                           data,
-                           follow=True)
-    assert response.status_code == 200
-    assert 'Enter a valid and useful out-of-date message' in response.content.decode()
-    assert len(mailoutbox) == 0
-
-
-def test_flag_package_invalid_denylist(client, package, denylist, mailoutbox):
-    data = {
-        'website': '',
-        'email': 'nobody@archlinux.org',
-        'message': 'check out https://bit.ly/4z3rty',
-    }
-    response = client.post('/packages/core/x86_64/linux/flag/',
-                           data,
-                           follow=True)
-    assert response.status_code == 200
-    assert 'Enter a valid and useful out-of-date message' in response.content.decode()
-    assert len(mailoutbox) == 0
-
-
-def test_flag_help(client):
-    response = client.get('/packages/flaghelp/')
-    assert response.status_code == 200
-
-
-def assert_flag_developer_package(client):
-    data = {
-        'website': '',
-        'email': 'nobody@archlinux.org',
-        'message': 'new linux version',
-    }
-    response = client.post('/packages/core/x86_64/linux/flag/',
-                           data,
-                           follow=True)
-    assert response.status_code == 200
-
-
-def test_flag_developer_package(developer_client, package):
-    assert_flag_developer_package(developer_client)
+def flag_package():
+    Package.objects.filter(pkgname='linux').update(flag_date=timezone.now())
 
 
 def test_unflag_package_404(developer_client, package):
@@ -78,14 +16,12 @@ def test_unflag_package_404(developer_client, package):
 
 
 def test_unflag_package(developer_client, package):
-    assert_flag_developer_package(developer_client)
+    flag_package()
     response = developer_client.get('/packages/core/x86_64/linux/unflag/', follow=True)
     assert response.status_code == 200
-    assert 'Flag linux as out-of-date' in response.content.decode()
 
 
 def test_unflag_all_package(developer_client, package):
-    assert_flag_developer_package(developer_client)
+    flag_package()
     response = developer_client.get('/packages/core/x86_64/linux/unflag/all/', follow=True)
     assert response.status_code == 200
-    assert 'Flag linux as out-of-date' in response.content.decode()

--- a/packages/urls.py
+++ b/packages/urls.py
@@ -9,8 +9,6 @@ package_patterns = [
     path('json/', display.details_json),
     path('files/', display.files),
     path('files/json/', display.files_json),
-    path('flag/', flag.flag),
-    path('flag/done/', flag.flag_confirmed, name='package-flag-confirmed'),
     path('unflag/', flag.unflag),
     path('unflag/all/', flag.unflag_all),
     path('signoff/', signoff.signoff_package),
@@ -23,7 +21,6 @@ package_patterns = [
 ]
 
 urlpatterns = [
-    path('flaghelp/', flag.flaghelp),
     path('signoffs/', signoff.signoffs, name='package-signoffs'),
     path('signoffs/json/', signoff.signoffs_json, name='package-signoffs-json'),
     path('update/', views.update),

--- a/templates/packages/package_details.html
+++ b/templates/packages/package_details.html
@@ -40,12 +40,6 @@
                 <li><a href="unflag/all/" title="Unflag all matching pkgbase">Click here to unflag all split packages</a></li>
                 {% endif %}
                 {% endif %}
-                {% else %}
-                <li><a href="flag/" title="Flag {{ pkg.pkgname }} as out-of-date">Flag Package Out-of-Date</a>
-                <a href="/packages/flaghelp/"
-                    title="Get help on package flagging"
-                    target="_blank"
-                    >(?)</a></li>
                 {% endif %}
                 <li><a href="download/" rel="nofollow" title="Download {{ pkg.pkgname }} from mirror">Download From Mirror</a></li>
             </ul>


### PR DESCRIPTION
Out of date information is now imported from bumpbuddy so manual flagging out of date is no longer required.